### PR TITLE
Rework PREV_KEY and pipeline graph construction

### DIFF
--- a/notebooks/experimental/impute-predict-screen.ipynb
+++ b/notebooks/experimental/impute-predict-screen.ipynb
@@ -1,0 +1,1515 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "veterinary-relationship",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2\n",
+    "\n",
+    "from vflow import Vset, build_vset, filter_vset_by_metric, init_args, dict_to_df, perturbation_stats\n",
+    "\n",
+    "from vflow.pipeline import build_graph\n",
+    "\n",
+    "from sklearn.datasets import make_classification\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "from sklearn.utils import resample\n",
+    "from sklearn.impute import SimpleImputer\n",
+    "from sklearn.ensemble import RandomForestClassifier\n",
+    "from sklearn.linear_model import LogisticRegression\n",
+    "from sklearn.neural_network import MLPClassifier\n",
+    "from sklearn.tree import DecisionTreeClassifier\n",
+    "from sklearn.metrics import accuracy_score, roc_auc_score\n",
+    "\n",
+    "from functools import partial\n",
+    "\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "pd.options.display.max_rows = 15\n",
+    "np.random.seed(31415)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "entitled-affiliate",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X, y = make_classification(n_samples=1000, n_informative=10)\n",
+    "\n",
+    "# 20% of X entries missing\n",
+    "i = np.random.randint(X.shape[0], size=round(X.shape[0]*X.shape[1] * 0.2))\n",
+    "j = np.random.randint(X.shape[1], size=i.size)\n",
+    "X[i, j] = np.nan\n",
+    "\n",
+    "# 2% outliers\n",
+    "i = np.random.randint(X.shape[0], size=round(X.shape[0]*X.shape[1] * 0.02))\n",
+    "j = np.random.randint(X.shape[1], size=i.size)\n",
+    "X[i, j] = X[i, j]*75\n",
+    "\n",
+    "X_trainval, X_test, y_trainval, y_test = train_test_split(X, y)\n",
+    "X_train, X_val, y_train, y_val = train_test_split(X_trainval, y_trainval)\n",
+    "\n",
+    "X_train, y_train = init_args([X_train, y_train], names=['X_train', 'y_train'])\n",
+    "X_val, y_val = init_args([X_val, y_val], names=['X_val', 'y_val'])\n",
+    "X_trainval, y_trainval = init_args([X_trainval, y_trainval], names=['X_trainval', 'y_trainval'])\n",
+    "X_test, y_test = init_args([X_test, y_test], names=['X_test', 'y_test'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "dental-community",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rf = RandomForestClassifier()\n",
+    "lr = LogisticRegression()\n",
+    "mlp = MLPClassifier()\n",
+    "dt = DecisionTreeClassifier()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "spatial-peter",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resample_set = Vset('resample', [partial(resample, n_samples=50) for i in range(10)])\n",
+    "impute_set = Vset('impute', [SimpleImputer(), SimpleImputer(strategy='median')], module_keys=['mean', 'median'], output_matching=True)\n",
+    "model_set = Vset('model', [rf, lr, dt], module_keys=['rf', 'lr', 'dt'])\n",
+    "\n",
+    "def accuracy_score_proba(y_true, y_pred_proba):\n",
+    "    ''' like accuracy_score, but y_pred is output from predict_proba\n",
+    "    '''\n",
+    "    return accuracy_score(y_true, np.argmax(y_pred_proba, axis=1))\n",
+    "\n",
+    "def my_roc_auc_score(y_true, y_pred_proba):\n",
+    "    ''' like roc_auc_score, but y_pred is output from predict_proba\n",
+    "    '''\n",
+    "    return roc_auc_score(y_true, y_pred_proba[:, -1])\n",
+    "\n",
+    "eval_set = Vset('eval', [accuracy_score_proba, my_roc_auc_score], module_keys=['acc', 'auroc'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "realistic-destination",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_trains, y_trains = resample_set(X_train, y_train)\n",
+    "X_trains = impute_set.fit(X_trains).transform(X_trains)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "wound-newton",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n",
+      "/home/james/miniconda3/envs/pcs-framework/lib/python3.8/site-packages/sklearn/linear_model/_logistic.py:762: ConvergenceWarning: lbfgs failed to converge (status=1):\n",
+      "STOP: TOTAL NO. of ITERATIONS REACHED LIMIT.\n",
+      "\n",
+      "Increase the number of iterations (max_iter) or scale the data as shown in:\n",
+      "    https://scikit-learn.org/stable/modules/preprocessing.html\n",
+      "Please also refer to the documentation for alternative solver options:\n",
+      "    https://scikit-learn.org/stable/modules/linear_model.html#logistic-regression\n",
+      "  n_iter_i = _check_optimize_result(\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<vflow.vset.Vset at 0x7fec3fbffb20>"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "model_set.fit(X_trains, y_trains)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "about-exploration",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "preds = model_set.predict_proba(impute_set.transform(X_val))\n",
+    "metrics = eval_set.evaluate(y_val, preds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "crude-pittsburgh",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>init-resample</th>\n",
+       "      <th>init-resample</th>\n",
+       "      <th>init-resample</th>\n",
+       "      <th>resample</th>\n",
+       "      <th>impute</th>\n",
+       "      <th>init-model</th>\n",
+       "      <th>init-model</th>\n",
+       "      <th>init-model</th>\n",
+       "      <th>model</th>\n",
+       "      <th>eval</th>\n",
+       "      <th>out</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>y_val</td>\n",
+       "      <td>X_val</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>resample_0</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>y_train</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>0.744681</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>y_val</td>\n",
+       "      <td>X_val</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>resample_1</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>y_train</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>0.617021</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>y_val</td>\n",
+       "      <td>X_val</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>resample_2</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>y_train</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>0.734043</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>y_val</td>\n",
+       "      <td>X_val</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>resample_3</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>y_train</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>0.648936</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>y_val</td>\n",
+       "      <td>X_val</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>resample_4</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>y_train</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>0.680851</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>...</th>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "      <td>...</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>115</th>\n",
+       "      <td>y_val</td>\n",
+       "      <td>X_val</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>resample_5</td>\n",
+       "      <td>median</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>y_train</td>\n",
+       "      <td>dt</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>0.543488</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>116</th>\n",
+       "      <td>y_val</td>\n",
+       "      <td>X_val</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>resample_6</td>\n",
+       "      <td>median</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>y_train</td>\n",
+       "      <td>dt</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>0.676139</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>117</th>\n",
+       "      <td>y_val</td>\n",
+       "      <td>X_val</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>resample_7</td>\n",
+       "      <td>median</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>y_train</td>\n",
+       "      <td>dt</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>0.590083</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>118</th>\n",
+       "      <td>y_val</td>\n",
+       "      <td>X_val</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>resample_8</td>\n",
+       "      <td>median</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>y_train</td>\n",
+       "      <td>dt</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>0.669121</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>119</th>\n",
+       "      <td>y_val</td>\n",
+       "      <td>X_val</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>resample_9</td>\n",
+       "      <td>median</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>X_train</td>\n",
+       "      <td>y_train</td>\n",
+       "      <td>dt</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>0.682467</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "<p>120 rows × 11 columns</p>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    init-resample init-resample init-resample    resample  impute init-model  \\\n",
+       "0           y_val         X_val       X_train  resample_0    mean    X_train   \n",
+       "1           y_val         X_val       X_train  resample_1    mean    X_train   \n",
+       "2           y_val         X_val       X_train  resample_2    mean    X_train   \n",
+       "3           y_val         X_val       X_train  resample_3    mean    X_train   \n",
+       "4           y_val         X_val       X_train  resample_4    mean    X_train   \n",
+       "..            ...           ...           ...         ...     ...        ...   \n",
+       "115         y_val         X_val       X_train  resample_5  median    X_train   \n",
+       "116         y_val         X_val       X_train  resample_6  median    X_train   \n",
+       "117         y_val         X_val       X_train  resample_7  median    X_train   \n",
+       "118         y_val         X_val       X_train  resample_8  median    X_train   \n",
+       "119         y_val         X_val       X_train  resample_9  median    X_train   \n",
+       "\n",
+       "    init-model init-model model   eval       out  \n",
+       "0      X_train    y_train    rf    acc  0.744681  \n",
+       "1      X_train    y_train    rf    acc  0.617021  \n",
+       "2      X_train    y_train    rf    acc  0.734043  \n",
+       "3      X_train    y_train    rf    acc  0.648936  \n",
+       "4      X_train    y_train    rf    acc  0.680851  \n",
+       "..         ...        ...   ...    ...       ...  \n",
+       "115    X_train    y_train    dt  auroc  0.543488  \n",
+       "116    X_train    y_train    dt  auroc  0.676139  \n",
+       "117    X_train    y_train    dt  auroc  0.590083  \n",
+       "118    X_train    y_train    dt  auroc  0.669121  \n",
+       "119    X_train    y_train    dt  auroc  0.682467  \n",
+       "\n",
+       "[120 rows x 11 columns]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_metrics = dict_to_df(metrics)\n",
+    "df_metrics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "prospective-legislature",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/james/school/yugroup/projects/pcs_inference/pcs_pipeline/veridical-flow/vflow/pipeline.py:143: UserWarning: This figure includes Axes that are not compatible with tight_layout, so results might be incorrect.\n",
+      "  plt.tight_layout()\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<networkx.classes.digraph.DiGraph at 0x7fec3fc07df0>"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAb4AAAEuCAYAAADx63eqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABYdUlEQVR4nO3dd3xO9///8UeWiBgJQhAShIoVjVUpkhhB7JFQIRErRtXW9qNWW1RRqwihRlC1KjVr1WhrhaJ2rZBEiJEpMs/vD79c36qVcSXnSq7X/Xbr7caVc97nlauS5/V+n/d5vw0URVEQQggh9ISh2gUIIYQQeUmCTwghhF6R4BNCCKFXJPiEEELoFQk+IYQQekWCTwghhF6R4BNCCKFXJPiEEELoFQk+IYQQekWCTwghhF6R4BNCCKFXJPiEEELoFQk+IYQQekWCTwghhF6R4BNCCKFXJPiEEELoFQk+IYQQekWCTwghhF6R4BNCCKFXJPiEEELoFQk+IYQQekWCTwghhF4xVrsAIfRBSkoKjx8/JjExkbS0NIyMjDAzM6NUqVKYmJioXZ4QesVAURRF7SKEKKgSEhKIjIwkJiYGgH//uBkYGABQokQJrK2tMTc3V6VGIfSNBJ8QuSQqKoqwsDDS09PfeayhoSE2NjZYWVnlQWVC6De5xydELnhd6PXv35+rV6++9vj09HTCwsKIiorK0XWnTp1Knz59AHjw4AEODg4kJSXlqE0hChoJPqG32rRpw+TJk195PTg4GGtra1JTU7PVrq2tLVu3bn0p9I4ePYq5uTk1atR443kZ4ZeQkJCt6/5X2bJlcXNzY/ny5VppT4iCQoJP6K1+/foRFBTEf0f7g4KC8Pb2xtg4e3O/0tLSXhne3Lp1Kx4eHu88Nz09ncjIyGxd93W8vb1ZtmyZ1toToiCQ4BN6q0uXLjx58oRjx45pXnv69Ck7d+7Ex8eH3bt3U7NmTYoVK0aFChWYM2eO5ridO3dSr149LCwscHZ25sKFC8CLoImIiGDMmDE0a9aMNWvWkJKSQkhICE5OTprz09PTWb16NZ07d6Zly5Z89tlnmgkwffv2ZcGCBS/V6ujoyLZt2wAYOXIkFStWpHjx4tSvX/+l+v+rcePG3Lp1i9DQ0Jy/YUIUEBJ8Qm+ZmZnh5eXF2rVrNa9t2rSJGjVq4OjoyIABA1i2bBlxcXFcvHiRFi1aAHD27Fn69+/PsmXLePz4Mf7+/nTq1ImkpCTmzp2LtbU13333HceOHcPX15e7d+9iYGBA2bJlNdfZuHEjhw8fZvny5ezZs4dixYoxa9YsANq2bcv69es1x16+fJnQ0FDat28PQMOGDTl37hxPnjyhd+/eeHp68vz589d+j8bGxtjb23P+/Hmtv39C5FcSfEKv+fr6snnzZhITEwFYu3Ytvr6+AJiYmHD58mViY2OxtLTU9NgCAwPx9/encePGGBkZ4evri6mpKSdOnNC0829xcXGvPKqwbds2hg0bRtmyZSlUqBD+/v4cPHiQ1NRUXF1duXjxoqaXtn79erp164apqSkAffr0oVSpUhgbGzN27FiSkpK4du3aG7/HYsWKER0dneP3SoiCQoJP6LWmTZtiZWVFcHAwt27d4vTp0/Tu3Rt4cV9u9+7d2Nra4uLiwvHjxwEIDQ1l7ty5WFhYaP67d+8eERERpKWlvXKN4sWLvzJh5f79+4wfPx5XV1dcXV3p0aMHRkZGPHnyBHNzc1xdXdm4cSPwonfo7e2tOXfu3Lk4ODhQokQJLCwsiImJ4dGjR2/8HuPi4rCwsMjpWyVEgSErtwi95+Pjw9q1a7l27Rru7u6aIcmGDRsSHBxMSkoK33//PV5eXty7d4+KFSsyceJEJk6c+Epbt2/f1jyYnqFSpUooisLDhw8pU6YM8GLG5eTJk6lXr95ra+rUqRMBAQE0b96cxMRE3NzcADh27BizZs3i4MGD1KpVC0NDQywtLV+ZoJMhNTWVGzdu4OjomN23R4gCR3p8Qu/5+Phw4MABAgMDNcOcycnJrF+/npiYGExMTChevDhGRkYADBo0iICAAE6ePImiKCQkJLBr1y7i4uIwMzOjZMmShIeHa9o3NjamUaNGnD17VvNa9+7dWbJkCffv3wdeTKo5fPgw8GJFl3bt2hEaGsrkyZPp2bMnhoYvflTj4uIwNjbGysqK1NRUvvzyS2JjY9/4vZ06dQo7OztsbW21+p4JkZ9J8Am9Z2dnh7OzMwkJCXTq1EnzelBQEHZ2dhQvXpyAgADWrVsHQIMGDQgMDKRv374YGRlRokQJvL29adCgAd27d8fPz4+VK1fi6upKUFAQ8CLodu/erWn7o48+onnz5gwfPpzmzZvTr18/Ll26pPl6+fLl6datGwcOHNAMvcKLZw/btWtH9erVsbW1pXDhwlSsWPGN39v69esZMmSI1t4rIQoCWbJMiGy6du0atWvXfulB9+bNm/PDDz+8djLJgAEDGD9+/FsfYgewsLCgatWqOa7v4cOHuLi48Ndff1G4cOEctydEQSH3+ITIhpiYGH755ReMjIxITU3FyMiIOnXqsH//flJSUoiNjX3lIfaVK1e+s11DQ0Osra21UmOZMmW4cuWKVtoSoiCRoU4hsuDu3buMHTuWypUrc/78eZYsWYKJiQkWFhbs3buXQoUKYW5ujo2Njea+XFbY2NjILg1C5DIJPiEy4ezZs3h7e1OvXj0MDAw4d+4c69atw8/Pj759+/Lrr7++9IC6lZVVlsIvLS2N1atXU6RIkdz6FoQQ/5/c4xPiDRRFYe/evcyZM4dr164xcuRIBg8eTIkSJTLdRmb34ytbtizDhw8HYPXq1a88EiGE0B4JPiH+IykpiQ0bNjB37lyMjIwYN24cPXv2pFChQtluMyUlhT/++IM///wTT09PjI2NX9mBPSEhgUaNGjF27Fj69++vrW9HCPEfEnxC/H9Pnz4lICCARYsWUadOHcaNG0erVq200vtKTk6mcuXKREREsGfPHtq2bfva465cuULz5s05ePAgdevWzfF1hRCvknt8Qu/dvn2bkSNHUrVqVa5evcrevXv59ddfad26tdaGHGfMmMHjx48BWLx48RuPc3BwYN68eXh6er71wXQhRPZJj0/ordOnTzNnzhwOHDjAwIEDGTFiBDY2Nlq/zrVr16hbty7JyckAmJqacv/+fSwtLd94jr+/PzExMfz4449yv08ILZMen9Ar6enp7NixAxcXF3r06MEHH3zA7du3mTVrVq6EHrzYVqh06dIYGhpiaGhIcnIye/bsees5CxYs4Nq1ayxdujRXahJCn0mPT+iF58+fExQUxNy5cylSpAjjx4+nR48emokleaF37964ubnRtGlTKleu/M7VVG7cuIGzszN79uyhfv36eVSlEAWfrNwiCrTHjx+zZMkSFi9eTP369Vm6dCmurq6qDB+Gh4djb2+Pg4NDpo63t7dnyZIleHl5cebMGdlaSAgtkaFOUSDdvHmTjz/+GHt7e+7cucPBgwfZtWsXbm5uqt0zCw8Pp0KFClk6p0ePHnTo0AE/P783bj0khMgaCT5RoJw4cYIePXrQuHFjihcvzuXLl1m5ciW1atVStS5FUbIVfACzZ88mIiKC+fPna78wIfSQ3OMT+V5aWho7duxgzpw5hIeHM3r0aPr370/RokXVLk3jyZMnVKlS5bW7NmTGnTt3aNy4Mdu3b6dJkybaLU4IPSP3+ES+lZiYyJo1a/juu++wsLBg3LhxdOvWDWNj3ftnnd3eXgY7OzsCAwPp1asXZ86coXTp0lqsTgj9onu/IYR4h6ioKBYvXszSpUtp3LgxK1asoFmzZjr9vFtOgw+gU6dO/P777/j4+LBz585s7f4ghJB7fCIfuX79OkOGDKF69epERERw5MgRfvnlF5o3b67ToQfaCT6A6dOnExsby6xZs7RQlRD6SYJP6DRFUfj999/p0qULH374IWXKlOHq1assX778nTuZ6xJtBZ+JiQkbN25k4cKFHDlyRAuVCaF/JPiETkpLS2Pr1q04OzvTr18/3N3duXPnDl9++eVL+97lFxEREVoJPnixWe2aNWvo3bs3Dx480EqbQugTCT6hUxISEli8eDHVq1dnzpw5jB8/nmvXrjFs2LB8vTN5eHg45cuX11p77u7uDBgwgN69e5OWlqa1doXQBxJ8Qic8ePCASZMmYWdnx8GDBwkKCuL48eN069YNIyMjtcvLMW0Ndf7blClTUBSFL7/8UqvtClHQSfAJVV25coVBgwZRo0YNHj9+zJ9//sm2bdtwdnZWuzStyo3gMzIyYsOGDaxYsYJ9+/ZptW0hCjIJPpHnFEXhyJEjdOzYEVdXVypWrMj169dZsmQJ1apVU7s8rUtOTubp06eUKVNG621bW1uzfv16fH19CQ8P13r7QhRE8hyfyDOpqals3bqVOXPmEBsby9ixY9m0aRNmZmZql5ar7t+/T9myZXNtyNbV1ZURI0bQq1cvfvvtN518gF8IXSI9PpHr4uPjWbBgAfb29ixevJhJkyZx5coVBg8eXOBDD3JnmPO/PvvsM4oWLcoXX3yRq9cRoiCQj4Yi10RERLBo0SICAwNp0aIFP/30E40bN1a7rDyXF8FnaGhIUFAQ9evXp2nTpnTo0CFXrydEfiY9PqF1Fy9exM/Pj1q1ahEfH8+pU6fYtGmTXoYe5E3wAZQuXZoff/yRAQMGEBoamuvXEyK/kuATWqEoCgcPHqRdu3a0bt0ae3t7bty4waJFi6hSpYra5akqr4IPwNnZmU8//RQvLy+Sk5Pz5JpC5DcSfCJHUlJS2LBhA/Xr12fEiBH06NGD27dvM3HiREqVKqV2eTohL4MPYPTo0ZQrV44JEybk2TWFyE/kHp/IltjYWFasWMH8+fOpWrUqX331Fe3atZMdA14jr4PPwMCAVatWUb9+fZo1a0b37t3z7NpC5AfyW0pkSVhYGBMmTKBy5cqcPn2abdu28dtvv9G+fXsJvTfI6+ADsLS0ZNOmTQwdOpQbN27k6bWF0HXym0pkyvnz5/Hx8aFu3bqkpKRw5swZfvzxRxo0aKB2aTpNURStr9OZWQ0aNGDKlCl4enry/PnzPL++ELpKgk+8kaIo7Nu3D3d3dzw8PKhVqxY3b95k3rx52NnZqV1evvD06VMKFSpE0aJFVbn+sGHDqF69OqNGjVLl+kLoIrnHJ16RnJzMxo0bmTNnDoqiMG7cOD766CMKFSqkdmn5jhrDnP9mYGBAYGAgDRo0YP369Xh7e6tWixC6QoJPaERHR7N8+XIWLlyIg4MDs2fPxt3dXed3N9dlagcfQPHixdm8eTOtWrXCyckJBwcHVesRQm0y1CkIDQ1lzJgxVKlShQsXLrBjxw72799PmzZtJPRySBeCD8DR0ZFvvvkGT09PEhIS1C5HCFVJ8Omxs2fP4u3tjZOTE4aGhpw/f55169bx/vvvq11agaErwQfQv39/6tevz7Bhw1AURe1yhFCNBJ+eURSFPXv20LJlSzp37oyTkxO3bt1izpw5VKxYUe3yChxdCj4DAwOWLFlCSEgIq1atUrscIVQj9/j0RFJSEhs2bGDOnDmYmJgwfvx4vLy8MDExUbu0Ai08PBwPDw+1y9AwNzdny5YtNG/enAYNGlC3bl21SxIiz0nwFXBPnz4lICCARYsWUbduXRYsWEDLli3l3l0e0aUeXwYHBwfmzZuHp6cnISEhFCtWTO2ShMhTBooM9hdIt2/fZv78+QQFBdGpUyfGjBkjn+7zSEpKCo8fPyYxMZFz585Rs2ZNSpQoQalSpXSqh+3v709sbCwbNmyQD0JCr0jwFTCnT59mzpw5HDx4kIEDBzJixAid63EUVAkJCURGRhITEwPw0gSSjGApUaIE1tbWmJubq1Ljvz1//pwmTZowePBghg4dqnY5QuQZCb4CID09nV27djFnzhzu3LnD6NGjGTBggAxh5aGoqCjCwsJIT09/57GGhobY2NhgZWWVB5W93Y0bN3B2dmbPnj3Ur19f7XKEyBMyqzMfe/78OYGBgdSsWZOpU6cydOhQbt68yahRoyT08sCHH37IX3/9laXQgxcfVMLCwoiKisrU8YcPH8bGxiZTx06dOpU+ffoA8ODBAxwcHEhKSnrj8fb29ixZsgQvLy+io6MzdQ0h8jsJvnzo0aNHfPXVV9jZ2REcHExAQAAhISH06tULY2P9na/Upk0bJk+e/MrrwcHBWFtbk5qamq127ezsOHDgwEuv7dixg2LFilG9evUshV6GjPDLzYfJy5Yti5ubG8uXL3/rcT169KB9+/b4+fnJ831CL0jw5SM3btxg+PDhVKtWjdDQUA4dOsTOnTtxdXWVyQlAv379CAoKeuWXd1BQEN7e3lr9UBAQEEDfvn2JjIzMcuhlSE9PJzIyUms1vY63tzfLli1753GzZ88mPDyc+fPn52o9QugCCb584Pjx43Tv3p0mTZpgaWnJlStXWLFiBTVr1lS7NJ3SpUsXnjx5wrFjxzSvPX36lJ07d+Lj48Pu3bupWbMmxYoVo0KFCsyZM0dz3M6dO6lXrx4WFhY4Oztz4cIFAPr27cvdu3fp2LEjRYsW5dtvvyU5OZlDhw7h7OysmciybNkyPv30UyZNmkTz5s3p2bMnoaGhrFq1itatW9O+fXtOnDihuV5UVBSjR4/GyckJe3t7AgMDNV9LTEykX79+WFpaUrNmTU6fPv3S9xkREUH37t2xsrKicuXKLFy48I3vSePGjbl16xahoaFvfe9MTU3ZtGkT33zzDcePH8/Euy1EPqYInZSamqr8/PPPirOzs1K5cmVl4cKFSnx8vNpl6byBAwcqAwYM0Pw9ICBAcXR0VBRFUaytrZWjR48qiqIoT548Uc6cOaMoiqKcOXNGsbKyUk6cOKGkpqYqq1evVmxtbZXnz58riqIotra2yv79+zVtXrx4USlSpIhy//595cyZM0pISIgyaNAgpVChQsqiRYuUEydOKB4eHkr58uWVoUOHKidOnFAmTpyolC9fXgkJCVFCQkIUJycnpUePHsqff/6p7N+/XyldurRy4MABRVEU5dNPP1WaNm2qPH78WLl7965Sq1YtpUKFCoqiKEpaWpri5OSkTJs2TUlKSlJu3rypVK5cWdm7d6+iKIoyZcoUxdvb+6X3pE6dOkpwcHCm3r/g4GClUqVKSlRUVFbfeiHyDenx6Zhnz54REBCAg4MDM2bMYNSoUVy/fp0RI0boxBR4Xefr68vmzZtJTEwEYO3atfj6+gJgYmLC5cuXiY2NxdLSEicnJwACAwPx9/encePGGBkZ4evri6mp6Us9tH+Ljo6mWLFiJCYmvjSsWq9ePZo0aYKxsTGtWrXi6dOn9OvXD2NjY9zd3YmIiCAuLo7IyEjOnTvHiBEjKFSoEFWrVmXgwIEEBQUBsGnTJiZOnEjJkiWpWLEin3zyieYap0+fJioqismTJ1OoUCGqVKnCoEGD2Lhx4xvfk2LFimV64kqnTp3o2bMnPj4+2R7CFULXSfDpiIcPHzJ16lQqV67Mnj17WLlyJSdPnsTT01OvJ6xkVdOmTbGysiI4OJhbt25x+vRpevfuDcDWrVvZvXs3tra2uLi4aIb0QkNDmTt3LhYWFpr/7t27R0RExGuvYWlpSVxcHGlpaS+9XqpUKc2fTU1NsbCwwMjISPN3ePHB5tGjRxQvXlzzQSYtLQ1bW1vCw8OBF0OZ/1431dbWVvPn0NBQIiIiXqp1xowZPHjw4I3vSVxcHBYWFpl6/wCmT59ObGwss2bNyvQ5QuQn8htVZdeuXWPevHn89NNPeHl5cfToUd577z21y8rXfHx8WLt2LdeuXcPd3Z2yZcsC0LBhQ4KDg0lJSeH777/Hy8uLe/fuUbFiRSZOnMjEiRNf295/Jw5Vq1YNRVGIiorK1ua8pUuXJjY2loSEBMzNzTEyMuLu3buahQbKlSvHvXv3qFWrFgB3797VnFuxYkUqV67MP//8k6lrpaamcuPGDRwdHTNdn4mJCRs3bqRhw4Y4Ozvj4uKShe9OCN0nPT4VKIrC77//TpcuXWjWrBlly5bl2rVrLFu2TEJPC3x8fDhw4ACBgYGaYc7k5GTWr19PTEwMJiYmFC9eXNMbGzRoEAEBAZw8eRJFUUhISGDXrl3ExcUBLx4LuHXrlqZ9ExMTWrVqxV9//ZWt2bTW1tbUrVuX77//nuTkZG7fvs3KlSs1u6N7eXkxc+ZMnj59SlhYGIsWLdKc26hRI4oXL86sWbNITEwkLS2NixcvvjIBJsOpU6ews7N7qdeYGTY2NqxZs4bevXu/tTcpRH4kwZeH0tLS2LJlC02aNMHPz482bdpw584dpk2bRpkyZdQur8Cws7PD2dmZhIQEOnXqpHk9KCgIOzs7ihcvTkBAAOvWrQOgQYMGBAYG8vHHH2NpaYm9vT2rV6/WnPf555/z9ddfY2FhoZkJ6u/vzy+//JLtGqdPn879+/dp27YtgwYNYtq0abRu3RqAKVOmYGtrS+XKlXF3d6dv376a84yMjNixYwfnzp2jcuXKlC5dmoEDB2pml/7X+vXrGTJkSLZqdHd3Z8CAAfTu3fuVYV0h8jNZsiwPJCQksGrVKubNm4e1tTXjxo2jU6dOmh6HyJ+aNm3KhAkTcrQWqoWFBVWrVtViVf/n4cOHuLi48Ndff1G4cOFstZGWlkbr1q1p1qwZ06ZN03KFQqhDgi8XRUZG8v3337Ns2TKaN2/O2LFjcXZ2VrssoUUJCQlcv349WzMgDQ0NqV69us7P1o2MjKR+/fqsWrUKd3d3tcsRIsdkqDMXXLlyhYEDB+Lg4MDTp085fvw4W7duldArQJKTk9m1axdubm6kpqZiaJi1H6WMhap1PfTgxT3J9evX4+vrq5l5KkR+JsGnJYqicOTIETp27Iibmxu2trb8888/LF68GHt7e7XLE1py5MgRevbsiaWlJV26dOH06dOUKlUKGxubTIefLu3OkFmurq6MGDGCXr16ZXvNUyF0hQx15lBqaipbt25lzpw5xMXFMXbsWPr06YOZmZnapYlc4OTkxPnz5zVDm/Xq1eOvv/4CYNWqVdjb22t6cYqO78eXVenp6bRv3x5HR0e++eYbtcsRItvkOb5siouLY+XKlcyfPx9bW1smT55M+/btszzkJfKX3bt3U61aNeLj4ylSpAiDBg0CYN68eYwZMwZPT0/Wr1+v2YE9LS0NIyMjzMzMdG4H9qwyNDQkKCiI+vXr07RpUzp06KB2SUJkiwRfFkVERLBo0SICAwNp0aIFP/30E40bN1a7LJEH0tPTmThxIrVr1+b+/fvcu3ePLl26MHz4cH744QcAzMzMMDExwdraWuVqc0fp0qX58ccf6dq1K6dOncry84FC6AIJvky6ePEic+fOJTg4mD59+nDq1CmqVKmidlkij6SnpzNw4EBu3rzJ/v37efbsGTt37mTMmDFs27aNlJQU4MUjBAWds7MzEyZMwMvLi2PHjmVr9Roh1CTjcm+hKAoHDx6kXbt2tG7dmmrVqnHjxg0WLlwooadH0tLSGDBgALdu3WL37t0ULVqUMmXK0L9/f7p06fLS7uiPHj1SsdK8M2bMGMqVK8eECRPULkWILJMe32ukpKSwadMm5syZQ1JSEuPGjWP79u2ahYaF/sgIvdDQUHbt2vXKpJRevXoRERHBvn37KFq0qN7c4zUwMGDVqlXUr1+fZs2a0b17d7VLEiLTZFbnv8TGxhIYGMiCBQuwt7dn3LhxtG3bVm9+mYmXpaWl0b9/f+7du8eOHTteOxMzPT2dGjVqsHr1ar18TjMkJAQPDw/+/PNPeWxH5BvyGx24d+8e48ePp3Llypw5c4aff/6ZQ4cO4eHhIaGnp9LS0vDz8yMsLIydO3e+8fGDQ4cOYWZmRpMmTfK4Qt3QoEEDpkyZgqenJ8+fP1e7HCEyRa9/q587d46+ffvi6OhIWloaZ8+eZcOGDdSvX1/t0oSKMkIvIiKCHTt2UKRIkTceu2TJEoYNG5atXRoKimHDhlG9enVGjRqldilCZEq+GepMSUnRyrNRiqKwb98+5syZw+XLlxk5ciSDBw/O0kadouBKS0ujX79+REZGEhwc/NbQCwsLo27duty9e5eiRYvmYZW6JzY2VtP7y9heSQhdpfPBl5CQQGRkpGbbleyuhpGcnMyPP/7I3LlzARg3bhy9evWSqdhCIy0tDV9fXx48eMAvv/zyztV3pkyZwpMnT17aL0+fnT9/nlatWnH06FEcHBzULkeIN9Lp4IuKiiIsLCxTK9+/af3D6Oholi9fzsKFC3FwcGDcuHG4u7vr9dCUeFVqaiq+vr5ERUURHBz8ztBLSUnB1taW/fv3a3ZKF7By5UrmzZvHyZMn8+WybEI/6Nw9vlq1anH48OF3hp6XlxchISGav6enpxMWFkZUVBQAoaGhjBkzhipVqvD333+zc+dO9u/fT5s2bST0xEtSU1Px8fHh0aNHmQo9gO3bt1O9enUJvf/o378/9evXZ9iwYejwZ2qh53Syx5fVPc6WLVtGWFgYX331FQDr1q1j7dq19O/fn08++YSKFSvmZrkiH0tNTaVv3748ffqUn3/+OdOLi7u5uTF06FC8vLxyucL8JyEhgUaNGjF27Fj69++vdjlCvEInH2CPjIzM1sae8KLn16ZNG6ZOnUqJEiW0XJkoSP4detu3b8/0LuVXrlzh6tWrdOnSJXcLzKfMzc3ZsmULzZs3p0GDBtStW1ftkoR4ic4Fn52dHZ9++il//fUXt2/fplChQhw+fBhra2umTp1KzZo1AejYsSNffPEFaWlprFq1CkVROHz4MDY2NmzcuPGts/GESE1NpU+fPsTExGQp9ACWLl3KwIEDZWLUWzg4ODBv3jw8PT0JCQmhWLFiapckhIbO3eNLS0vT/Pno0aO4u7vz22+/0bx5c7799ttXjnd2dsbPzw93d3eOHTvGjz/+CMDjx4/zrGaRv6SkpNC7d29iY2P5+eefsxR68fHxrFu3jsGDB+dihQVDnz59cHV1ZfDgwXK/T+gUnQs+RVE0PyT16tWjadOmGBkZ4eHhwT///JPpNhITE3OzTJFPZYReQkIC27Zty1LoAWzYsAEXFxe5b5xJCxYs4OrVqwQEBKhdihAaOhd8/1aqVCnNnwsXLkxSUhKpqamZOvffPUch4EXoffTRRzx79ixboacoCkuXLmXo0KG5VGHBU7hwYTZv3syUKVM4c+aM2uUIAeh48GXW6x5PMDIyUqESoasyQu/58+ds27YtWzttnDhxgvj4eFq1apULFRZc9vb2LF68GC8vL6Kjo9UuRwjdCz4DA4MsP2dXsmRJIiIiNDNBDQwMMj0tXRR8KSkp9OrVi6SkJLZu3Zrt7aWWLFnC0KFDZeHybPD09KR9+/b4+fnJ/T6hOp37Cc5OTy3jE3jLli016wT+e5hU6K/k5GR69uxJSkoKW7ZsyXboRUVFsXPnTvr166fdAvXI7NmzCQ8PZ/78+WqXIvScTj7AfvPmzRwNiVhYWFC1alXtFSTypYzQS0tLY/PmzTnaSPjbb7/lypUrrFq1SosV6p87d+7QuHFjtm/frrdbOQn16VyPD8Da2jrbw0mGhoZYW1truSKR3yQnJ+Pl5UV6enqOenrwYqJUQEAAw4YN02KF+snOzo7AwEB69erFo0eP1C5H6CmdDD5zc3NsbGyyHH5JSUmULl1aFsfVcxmhB7B58+YcP2j+66+/UqpUKRo2bKiN8vRep06d6NmzJz4+PtleoUmInNDJ4AOwsrLKdPilp6djYGDAqVOnNM9oCf2UnJyMp6cnBgYGbNq0SSurq8gjDNo3ffp0YmNjmTVrltqlCD2kk/f4/i0z+/HdvXuXY8eOMXv2bAYOHMidO3fYuXOnLFumZ5KSkvD09MTY2JiNGzdqJfTu3LlDgwYNuHv3rvx70rKwsDAaNmzIxo0bcXFxUbscoUd0PvgyvG0H9uTkZGrXrk1gYCBubm7069ePhw8fEhwcnOWHlEX+lJSURI8ePTAxMeGnn37CxMREK+1+/vnnJCUl8d1332mlPfGyffv24efnx9mzZylbtqza5Qg9kW+C7112797NyJEjuXDhAiYmJnh7exMfH5/th5VF/pGUlET37t0xNTVl48aNWgu9pKQkKlWqxLFjx6hevbpW2hSvmjx5Mn/88Qf79u2ThSdEntDZe3xZ5eHhQb169ZgxYwbGxsasW7cOU1NTzTNcomDKCL3ChQtrNfQAtm7dSt26dSX0ctmUKVNQFEWzn6YQua3A9PgAIiIicHR05OjRozg4OJCcnEz37t0xMzNjw4YNGBvr3C5MIgeeP39O9+7dKVKkCBs2bNBq6AE0bdqUsWPH0rVrV622K14VGRlJ/fr1Wb16Na1bt1a7HFHAFZgeH0D58uWZOnUq/v7+pKenU6hQIbZs2UJcXBy+vr6ycHUB8vz5c7p164a5uXmuhN758+cJDQ2lY8eOWm1XvJ61tTXr16/Hx8eH8PBwtcsRBVyBCj6AIUOG8Pz5c1avXg2Aqakp27Zt48GDBwwYMECeGyoAnj9/TteuXSlatCjr16/XeujBi0cYBg0aJKMEecjV1ZURI0bQq1evTO/CIkR2FKihzgznzp2jTZs2XLx4ESsrK+DFYxEeHh689957BAQEyELD+VRG6BUvXpz169fnSjDFxsZia2vLpUuXKF++vNbbF2+Wnp5O+/btcXR05JtvvlG7HFFAFcjf/vXq1aNv376MGzdO85q5uTk7d+7k0qVLfPLJJ7JCfD70/PlzunTpQokSJXIt9ACCgoJo3bq1hJ4KDA0NCQoKYsOGDezcuVPtckQBVSB7fADx8fHUqlWLVatW0aJFC83rMTExuLu74+zszHfffZflLZCEOhITE+nSpQslS5YkKCgo10JPURRq167N4sWLcXV1zZVriHf7888/6dq1K6dOncLW1lbtckQBUyB7fABFixbl+++/19zzy1CiRAn27t3LkSNH+Oyzz6Tnlw8kJibSuXNnSpUqlauhB3Ds2DEURZGVRFTm7OzMhAkT8PLyIjk5We1yRAFTYIMPoGPHjtSpU+eVewWWlpbs37+fPXv2MGXKFJWqE5mREXpWVlasXbs21yebZGw2KyMB6hszZgzlypVjwoQJapciCpgCO9SZITw8nHr16nHs2DFq1Kjx0tcePnyIm5sbH330EV988YVKFYo3efbsGZ07d6ZMmTKsWbMm10MvMjISBwcH7ty5Q4kSJXL1WiJznj59Sv369Zk9ezbdu3dXuxxRQBToHh9AhQoVmDRpEkOGDHllWLNMmTIcPHiQdevW8e2336pUoXidZ8+e0alTJ8qWLZsnPT2AFStW4OnpKaGnQywtLdm0aRNDhw7lxo0bapcjCogCH3wAw4cPJz4+njVr1rzyNWtraw4ePMjy5cuZP39+3hcnXvHs2TM6duxIuXLlWLNmTZ6s35iamsry5ctls1kd1KBBA6ZMmYKnp+dL9+uFyC69CD4jIyOWL1/OZ5999tpdnytUqMChQ4dYsGABS5YsUaFCkSEj9CpUqMDq1avzbNHiXbt2YWNjQ7169fLkeiJrhg0bRvXq1Rk1apTapYgCQC+CD8DJyYnevXszfvz41369UqVKHDp0iFmzZrFixYo8rk7Ai0UGOnTogI2NDatWrcrTlfqXLFkivT0dZmBgQGBgIIcOHWL9+vVqlyPyuQI/ueXf4uPjqVmzJmvXrn3jM1o3btzAzc2Nr7/+Gl9f37wtUI9lhJ6trS0rV67M09D7559/+PDDD7l7967s36jjzp8/T6tWrV47WU2IzNKbHh+8eLZv0aJFDBkyhKSkpNceY29vz/79+/nf//7Hhg0b8rhC/ZQRenZ2dnkeegDLli3Dz89PQi8fyFjKrEePHjx79kztckQ+pVc9vgxdu3bl/fffZ/LkyW885tKlS7Rq1YpFixbRo0ePPKxOvyQkJNC+fXuqVKlCYGBgnodeYmIilSpV4uTJk1SpUiVPry2yR1EU+vXrh6GhIatWrVK7HJEP6VWPL8PChQtZuHAh169ff+MxtWrVYu/evXz88ccEBwfnYXX6Iz4+Hg8PD6pWrcqKFStU2X37p59+olGjRhJ6+YiBgQFLlizh1KlTEnwiW/Qy+CpWrMgXX3zB0KFD37pkmaOjI7t27WLw4MHs3r07Dyss+DJCr1q1agQGBqq2W0bGSi0ifzE3N2fLli1MmDCBCxcuqF2OyGf0MvgAPv74Y6Kjo1m3bt1bj6tfvz6//PIL/fr1Y9++fXlUXcGWEXrvvfcey5cvVy30QkJCePjwIe3atVPl+iJnHBwcmDdvHp6ensTFxaldjshH9PIeX4aQkBA6dOjApUuXKFWq1FuP/eOPP+jatSs//fQTbm5ueVRhwRMXF4eHhwcODg6q74s4YMAAqlWrxmeffaZaDSLnBg8eTFxcHBs2bJA1VkWm6HXwAYwcOZL4+HhWrlz5zmMPHz6Ml5cXW7dupVmzZnlQXcESFxdHu3btqFWrFkuXLlU19J4+fUrlypW5fv06ZcqUUa0OkXOJiYk0adIEf39/GbYWmaL3wRcbG0utWrVYv349zZs3f+fxBw4coHfv3gQHB9OkSZM8qLBgyAi92rVrs2TJElVDD2D+/PmcPn1aHoYuIP755x+cnZ3Zu3cv9evXV7scoeP09h5fhuLFi7Nw4UL8/f3f+Gzfv7Vq1Yq1a9fSpUsXQkJC8qDC/C82Npa2bdtSp04dnQi99PR0WamlgKlWrRpLlizBy8uL6OhotcsROk7vgw+gS5cuVKtWjdmzZ2fq+LZt27JixQrat2/PX3/9lcvV5W8Zoefo6MjixYtVDz2AQ4cOYWZmhrOzs9qlCC3y9PSkffv2+Pn5yQbT4q30fqgzw927d3FycuL48eNUq1YtU+ds27aN4cOHs3//fmrXrp3LFeY/GaFXr149Fi9erDMTD7p164a7uztDhgxRuxShZUlJSTRr1oyPPvqI0aNHq12O0FESfP/y3XffsWfPHvbt25fpX9IbN25kzJgxHDx4EAcHh1yuMP+IiYmhbdu2ODk58f333+tM6IWFhVG3bl1CQ0MpVqyY2uWIXHDnzh0aN27M9u3b5T68eC31x510yCeffMKjR4+ytEZnr169mDVrFq1bt37rSjD6JCYmhjZt2lC/fn2dCj2AwMBAevfuLaFXgNnZ2bFixQp69er12m3IhJAe33+cOnWKzp07c+nSJUqWLJnp83744QemTp3K4cOH9Xr5q4zQa9iwIQsXLtSp0EtJScHW1pb9+/dTq1YttcsRuWzChAlcvHiRnTt36sS9ZaE75F/DfzRq1IgePXpk+aHm/v3787///Y+WLVsSGhqaS9XptujoaNzd3WnUqJHOhR7A9u3bqVatmoSenpg+fTqxsbHMmjVL7VKEjpEe32vExMRQq1YtNm7cSNOmTbN07sKFC1mwYAFHjhzBxsYmlyrUPRmh16RJE+bPn69zoQfQokUL/P396dmzp9qliDwSFhZGw4YN2bhxIy4uLmqXI3SE9Pheo0SJEsyfPx9/f3+Sk5OzdO4nn3zCsGHDaNGiBffv38+lCnVLRug5OzvrbOhduXKFK1eu0LVrV7VLEXnIxsaGNWvW4O3tzYMHD9QuR+gICb436N69O5UrV2bOnDlZPnfs2LH069ePli1b8vDhw1yoTnc8ffqU1q1b8+GHHzJv3jydDD2ApUuXMmDAAAoVKqR2KSKPubu7079/f7y9vUlLS1O7HKEDZKjzLe7cuUODBg04efIkVatWzfL5U6dOZdu2bRw6dIjSpUvnQoXqygi95s2bM3fuXJ0Nvfj4eCpVqsS5c+eoVKmS2uUIFaSlpWn+rU6dOlXtcoTKpMf3FnZ2dnz66acMGzYsWytBTJkyhQ4dOtC6dWuePHmSCxWq58mTJ7Rq1QoXFxedDj2AH3/8kebNm0vo6TEjIyM2bNhAYGAg+/fvV7scoTIJvncYNWoUkZGRbNy4McvnGhgYMH36dFq2bEmbNm2IiYnJhQrzXkboubm5MWfOHJ0OPUVRZLNZAYC1tTXr1q3Dx8eH8PBwtcsRKpKhzkw4ceIE3bp149KlS1haWmb5fEVRGDlyJKdPn2bfvn35+uHpjNBr2bIl3377rU6HHsDx48fp27cv169fl2e5BPDiMYe9e/fy22+/YWxsrHY5QgUSfJk0fPhw0tLSCAgIyNb5iqIwdOhQLl++zJ49ezA3N9dyhbnv8ePHtGrVitatWzNr1iydDz0AHx8fHB0dGTt2rNqlCB2Rnp6Oh4cH9erV45tvvlG7HKECCb5MiomJoWbNmmzevDnbq/qnp6czcOBA7ty5w86dOylSpIiWq8w9GaHn7u7ON998ky9C79GjR1SrVo0bN25QqlQptcsROuTRo0c4OTmxZMkSOnTooHY5Io/J2E8mlShRgnnz5uHv709KSkq22jA0NCQwMJAKFSrQtWtXnj9/ruUqc8ejR4809ynzS+jBi2XkOnfuLKEnXlG6dGk2btzIgAED9HalJX0mPb4sUBSF9u3b4+LiwqeffprtdlJTU/H29iYhIYFt27bp9LNlGaHn4eHBjBkz8k3opaenY29vz8aNG2nUqJHa5QgdNXfuXDZt2sSxY8d0+udQaJcEXxbdvn2bhg0bcurUqRwtRp2SkkLPnj1RFIVNmzZhYmKixSq1IyP02rdvz/Tp0/NN6AHs2bOHSZMmcfr06XxVt8hbiqLQtWtX7OzsmD9/vtrliDwiQ51ZVLlyZcaPH8/w4cNztMuziYkJGzdu1PT+UlNTtVhlzkVFRdGiRQs6dOiQ70IPYMmSJQwbNizf1S3yloGBAatWreKXX35h69atapcj8oj0+LIhJSUFJycnJk2ahJeXV47aSkpK0tyHWrt2LUZGRlqqMvuioqJo2bIlnTp14quvvsp34XHnzh3q16/PvXv38tUEIqGekJAQPDw8+PPPP7G3t1e7HJHLpMeXDSYmJixbtozRo0cTHR2do7ZMTU35+eefiYyMZODAgaSnp2unyGx6+PAhLVq0oHPnzvky9ACWLVuGj4+PhJ7ItAYNGjBlyhQ8PT3zzaQzkX3S48uBIUOGYGhoyJIlS3LcVkJCAh4eHrz33nsEBASo8rB1Ruh169aNadOm5cvQS0pKolKlShw9epT33ntP7XJEPqIoCr169aJkyZIsXbpU7XJELpIeXw7MnDmT7du3c+LEiRy3ZW5uzs6dO7l06RKffPJJju4fZkdG6HXv3j3fhh7A1q1bqVOnjoSeyDIDAwMCAwM5ePAgGzZsULsckYsk+HLA0tKS7777LkfP9v1bsWLF2L17N6dOnWLMmDF5Fn4PHjzAzc2NHj165OvQg/+b1CJEdhQvXpzNmzczcuRIrl69qnY5IpdI8OVQz549sba21tpU6BIlSvDrr79y5MgRPvvss1wPvwcPHtCiRQs8PT3z/XYtFy5c4M6dO3Tq1EntUkQ+5ujoyMyZM+nRowfPnj1TuxyRC+QenxbcvHmTxo0bExISgp2dnVbafPz4MW5ubnTp0oUvv/xSK23+V2RkJC1atKBnz55MmTIlV66Rl4YOHUq5cuWYPHmy2qWIfE5RFHx9fTEyMmLVqlVqlyO0TIJPS2bOnMnvv//Ozp07tTZU+PDhQ9zc3Pjoo4/44osvWL16NTVr1tTKSiSRkZGatgtCUMTGxmJra8ulS5coX7682uWIAiAhIYFGjRoxbtw4/Pz81C5HaJEEn5YkJyfz/vvvM23aNHr06KG1diMjI3FxcaFKlSrs27ePtm3bsmvXrhy1ef/+fVq0aEHv3r2ZNGmSlipV1+LFizl8+DCbN29WuxRRgFy+fBkXFxcOHjxI3bp11S5HaInc49OSQoUKsWzZMkaNGqXVDWetra3p0KEDv/76K+np6Rw6dChHzxndv38fNzc3vL29C0zoKYrC0qVLZVKL0LqaNWsyb948PD09iYuLU7scoSXS49OywYMHY2pqyqJFi7TS3t69e2nXrp3m74ULF2bz5s0vbaWSkpLC48ePSUxMJC0tDSMjI8zMzChVqtRLa4BmhF7fvn2ZOHGiVurTBUePHsXf35/Lly/n6xmpQncNHjyYuLg4NmzYIP/GCgAJPi178uQJtWrVIjg4WCv34pKTkwkODiYwMJAjR46QnJysWSQ7ISGByMhITQ/z3/8rM344S5QogbW1NTExMbi5ueHr68v//ve/HNelS3r16oWzszOffPKJ2qWIAioxMZEmTZrg7+/P0KFD1S5H5JAEXy5Yv349s2fPJiQkBGNjY621GxMTQ0BAANeuXWPWrFmEhYVlaokzAwMDVqxYQcWKFfn888+1Vo8uiIyMxMHBgdu3b2NhYaF2OaIA++eff3B2dmbv3r3Ur19f7XJEDkjw5QJFUXB3d6dt27aMHTs2U+d8+OGHfP/997z//vvvPDYqKirToZchPT0dOzs7rKysMn1OVty5c4fKlSuTkpLyzrD/5Zdf2LBhAxs3bszxdadPn05oaCjLly/PcVtCvMvmzZv57LPPOHPmjHzQysdkcssbtGnT5rXT/IODg7G2tn7rNkIGBgYsXbqUmTNnvrK7s52dHQcOHHjptR07dlCsWLFMhV5CQkKWQw9e7P4eFhZGQkJCls7LDZ06deLixYtcuHAhR+2kpqaybNkyGXoSecbT05P27dvj5+eX58sKCu2R4HuDfv36ERQU9Mo/7qCgILy9vd/Zq7G3t2fUqFF8/PHH7/wBCQgIoG/fvm/8+r9DNjIyMts7OKSnpxMZGZmtc7Xto48+ynEvbdeuXVSoUCFTHxiE0JbZs2cTHh4uG9fmZ4p4rWfPninFixdXjhw5onntyZMniqmpqXLu3Dll165dioODg1K0aFGlfPnyyuzZszXH7dixQ3F0dFRKlCihmJmZKXPnzlUURVH69OmjGBgYKIULF1bMzc2VWbNmKUlJSUrhwoWVe/fuac6fMmWK0r17d8Xb21spVqyYEhgYqERHRyv9+vVTSpUqpVhZWSn9+/dXTp48qYSEhCg///yz4uTkpJibmyslSpRQWrdurYSEhCghISFKr169lLJlyyrm5uZKjRo1lBUrVijJycma6/To0UPx9vZWihYtqtSuXVu5du2aMmPGDMXKykqxsbFRfv31V01dLi4uymeffaY0bNhQKV68uNKpUyfl8ePHiqIoyu3btxVASUlJURRFUaKjo5X+/fsr1tbWSvny5ZWJEycqqampmrZ+//13xc7OLkf/j9q0aaOsXbs2R20IkR23b99WypQpoxw/flztUkQ2SPC9xcCBA5UBAwZo/h4QEKA4OjoqiqIo1tbWytGjRxVFeRGIZ86cURRFUc6cOaNYWVkpJ06cUFJTU5XPP/9cMTIyUh4+fKgoiqLY2toq+/fv17R58eJFpUiRIi9dd8qUKYqxsbHy888/K2lpacqzZ8+Uzp07K3369FF+//13Zd++fUrNmjWVzz//XAkJCVHc3d2VoUOHKqdOnVL++OMPZcWKFZrg+/LLL5UDBw4oJ06cUEaNGqWUKlVKuX37tuY6pqamyt69e5WUlBSlb9++ip2dnfL1118rycnJyvLly18KJxcXF6V8+fLK33//rcTHxyvdunVTvL29FUV5Nfg6d+6sDB48WImPj1cePHigNGzYUAkICNC09fjxYwVQYmJisvX/5p9//lGsrKyUxMTEbJ0vRE4FBwcrlSpVUh49eqR2KSKLZKjzLXx9fdm8eTOJiYkArF27Fl9fX+DFZrSXL18mNjYWS0tLnJycAAgMDMTf35/GjRtjZGTEjBkzKFq0KEOGDHntNaKjoylWrNgrrzdp0oQuXbpgaGhIbGwse/bs4X//+x+FCxemZMmS9O7dm3379gFgbGxMZGQkUVFRmJqaUq9ePU07Hh4eWFhYYGxsTJ8+fUhOTuby5cuarzdr1ow2bdpgbGyMp6cnUVFRfPbZZ5iYmNCrVy/u3Lnz0ma7ffv2pXbt2pibm/PVV1+xadMm0tLSXqr9wYMH7Nmzh/nz52Nubk6ZMmUYPXr0S5NZMr7n7G7kGxAQQL9+/ShcuHC2zhcipzp16kTPnj3x8fFRfQNpkTUSfG/RtGlTrKysCA4O5tatW5w+fZrevXsDL/Z92717N7a2tri4uHD8+HEAQkNDmTt3LhYWFpr/kpOTOXDgACEhIa9cw9LS8rUrQlSsWFHz59DQUFJSUmjcuDGurq64uroyc+ZMnj59CqDZv8/X1xcvLy+Cg4M1565bt44ePXrg4uKCq6sr8fHxPHr0SPP1smXLav5sZmZG6dKlMTIy0vwdID4+/rV12drakpKS8lJ7/663XLlymvfA39+fhw8fao7J+J6zMzMuMTGR1atX4+/vn+VzhdCm6dOnExMTw7fffqt2KSILtPeQWQHl4+PD2rVruXbtGu7u7pqgaNiwIcHBwaSkpPD999/j5eXFvXv3qFixIhMnTnxlZZSgoCD8/f1fWfWhWrVqKIpCeHg4FSpU0Lz+7+MqVqyIqakpZ86cITY29pUaS5cuzRdffAHAuXPnGDZsGE5OTjx69Ig1a9awdOlSqlSpgqGhIW5ubjlaeeLevXuaP9+9excTExNKly790usZ9T569OiNk4CuXLmCnZ0dxYsXz3INmzZtolGjRlStWjXr34AQWmRiYsLGjRtp0KABTZo0wcXFRe2SRCZIj+8dfHx8OHDgAIGBgZphzuTkZNavX09MTAwmJiYUL15c00saNGgQAQEBnDx5EkVRSEhIYNeuXXTu3BkLCwsUReHWrVua9k1MTGjVqhVHjhx5Yw3lypXD3d2dWbNmkZCQQHp6OmFhYZw5cwaAAwcO8ODBA+DFEKKBgQGGhoYkJCRgZGSEhYUFaWlpBAYGkpCQgKmpabbfj3Xr1nH58mWePXvG5MmT6dGjh+Z7/2+9Y8eOJTY2lvT0dG7evPnS93jkyJGXlmLLiiVLlsgjDEJn2NjYsHr1ary9vTU/h0K3SfC9g52dHc7OziQkJLy0wWlQUJCmxxIQEMC6desAaNCgAYGBgXz88cdYWlpib2/P6tWrNc/2PXnyhGnTpmFhYcGcOXMA8Pf3Jygo6K11rF27FiMjIzw9PXFzc2PChAmaIcZLly7Rr18/mjVrxpgxYxg7diwVKlSgSZMmODs70717dzp06EChQoUoW7ZstnpZGfr27Uu/fv2wtrbm+fPnLFy48I31JicnU7NmTSwtLenRowf379/XfP3HH3/M1lDlmTNniIyMxMPDI9vfgxDa1rZtW/z8/PD29n7lnrfQPbJySx778ssvOXv2LNu3b3/p9aZNm7Jo0aJ3PpN28+bNbE8IgRf31LI7ROjq6kqfPn0YOHBgtq8PLx7YDwoKYtOmTVk+d+DAgVStWrXALb0m8r+0tDRat25N8+bNmTp1qtrliLeQ4MtjSUlJODo68s0339ClS5csn5+QkMD169ezNYvM0NCQ6tWrY25unuVzQXvBl11Pnz6lSpUqXLt2jTJlyqhSgxBvExkZSf369Vm9ejWtW7dWuxzxBjLUmcdMTU0JCAjgk08+ydb+Xubm5tjY2GBomLX/dYaGhtjY2GQ79HTBmjVraNeunYSe0FnW1tasW7cOHx8fwsPD1S5HvIH0+FTi5+eHhYUF8+bNy9b5WVmoOiP0cmuB6rygKAo1atRg5cqVNG3aVO1yhHir6dOns3fvXn777Tet7tAitEOCTyWPHj2idu3a7N69W/Pwe1a9bT++5ORkTExMsLS0xNraOl/39AAOHjzI6NGjOX/+vGwEKnReeno6Hh4e1KtXj2+++UbtcsR/SPCpaM2aNSxatIiTJ0++8khAVrxuB/bDhw9z584dpk2bpsWK1dO9e3datWoljzGIfOPRo0c4OTmxZMkSOnTooHY54l8k+FSkKAotWrSga9euWt89/OTJk/j5+b20PFl+FR4eTp06dQgNDX3t8m5C6Ko///yTrl27curUKWxtbdUuR/x/Enwqu3r1Kk2bNuXcuXPY2Nhord309HQqVKjA0aNHqVatmtbaVcPUqVOJiopi8eLFapciRJbNnTuXzZs3c/ToUQoVKqR2OQKZ1am6GjVq8PHHHzNy5EittmtoaEjHjh355ZdftNpuXktJSSEwMFCGOEW+NWbMGKytrfn000/VLkX8fxJ8OuCzzz7j77//1npIde7c+aUFq/Oj4OBgqlatSu3atdUuRYhsMTAwYNWqVQQHB7Nt2za1yxHIUKfOOHToEH5+fly6dImiRYtqpc3nz59TtmxZbt68SenSpbXSZl5r2bIlgwYNolevXmqXIkSOhISE4OHhwfHjx2WBdZVJj09HtGjRAldXV60udVS4cGFatWrFrl27tNZmXrpy5QqXLl2iW7duapciRI41aNCAyZMn4+npyfPnz9UuR69J8OmQOXPmEBQUxF9//aW1Njt16pRvhzsDAgIYOHCgTAgQBcbw4cOxt7dn9OjRapei12SoU8f88MMPBAQEcPz48Rw925fh0aNHVK1alcjISM3GsvlBQkIClSpV4q+//qJSpUpqlyOE1sTGxlK/fn2mTZum2dha5C3p8ekYPz8/zMzMWLp0qVbaK126NPXq1ePQoUNaaS+v/PjjjzRt2lRCTxQ4xYsXZ8uWLYwcOZKrV6+qXY5ekuDTMQYGBgQEBDBt2jQiIiK00mZ+G+5UFIXFixczbNgwtUsRIlc4Ojoyc+ZMevTowbNnz9QuR+/IUKeOmjRpElevXmXz5s05buvGjRs0a9aM8PDwLO/qoIYTJ07Qp08frl+/ni/qFSI7FEXB19cXIyMjVq1apXY5ekV+q+io//3vf5w7d04rMzLt7e0pWbIkp0+f1kJluW/p0qUMGTJEQk8UaAYGBixdupRTp05J8OUx6fHpsAMHDjBo0CAuXryY490VPv/8cwwMDJgxY4aWqssdjx49olq1aty4cYNSpUqpXY4Que7y5cu4uLhw8OBB6tatq3Y5ekE+UuuwVq1a0bRpU63ssJBfVnFZtWoVnTt3ltATeqNmzZrMmzcPT0/PbG1OLbJOenw67uHDh9SuXZv9+/fj6OiY7XbS09MpX748v//+O/b29lqsUHvS09OpVq0aGzZsoHHjxmqXI0SeGjx4MHFxcWzYsEH2nMxl0uPTcWXKlGHGjBn4+/tnarf1N8kPi1bv27cPCwsLGjVqpHYpQuS5BQsWcOXKFZYtW6Z2KQWeBF8+0L9/f0xMTHL8A6Hrw51Llixh2LBh8mlX6CUzMzM2b97M5MmTOXv2rNrlFGgy1JlPXLp0CVdXVy5cuEC5cuWy1UZiYiJly5bl9u3bOncPLTQ0FCcnJ+7du0eRIkXULkcI1WzevJnPPvuMM2fOYGFhoXY5BZL0+PKJWrVqMXjwYEaNGpXtNszMzGjZsqVOLlq9fPly+vbtK6En9J6npyft27enf//+SL8kd0jw5SNffPEFZ86cYc+ePdluQxeHO5OSkli5cqVsNivE/zd79mzCwsJYsGCB2qUUSDLUmc/s27ePIUOGcPHixWz1jqKiorC3t+fBgwcULlw4FyrMuh9//JGVK1dy4MABtUsRQmfcvn2bDz74gODgYD744AO1yylQpMeXz7i7u/PBBx/w5ZdfZut8Kysr6tatq1OLVi9ZskR6e0L8R+XKlQkMDKRnz548fvxY7XIKFOnx5UORkZHUrVuXgwcPUqdOnSyfP2fOHP755x+dmDb9999/07ZtW+7cuYOJiYna5Qihc8aPH8/ly5fZsWOHLOOnJfIu5kPW1tZ8/fXX2X62r3PnzuzYsSNHzwVqy9KlSxk8eLCEnhBvMGPGDKKjo/n222/VLqXAkODLpwYOHIiBgQGBgYFZPrdatWqUKFGCkJCQXKgs8+Li4ti4cSODBg1StQ4hdJmJiQk//fQT8+fP58iRI2qXUyBI8OVThoaGBAQE8MUXXxAZGZnl83Vhdue6deto0aIF5cuXV7UOIXSdjY0Nq1evxtvbmwcPHqhdTr4nwZeP1alTh4EDBzJmzJgsn9u5c2dVly9TFEWzUosQ4t3atm2Ln58f3t7epKWlqV1OvibBl89NmjSJEydO8Ouvv2bpvEaNGvHw4UNu3bqVS5W93e+//05KSgpubm6qXF+I/Gjq1Kmkp6fz1VdfqV1KvibBl88VKVKExYsXM2zYMBITEzN9npGRER07dlRtuHPp0qWyLqcQWWRkZMSGDRsIDAxk//79apeTb0nwFQDt2rWjYcOGfP3111k6T63hzgcPHrBnzx58fHzy/NpC5HfW1tasW7cOX19fIiIi1C4nX5Ln+AqI+/fv4+joyG+//UatWrUydU5iYiLW1tbcunUrTxetnjFjBrdv387WjFQhxAvTp0/n119/5dChQxgbG6tdTr4iPb4Coly5ckybNi1Lz/aZmZnh5ubG7t27c7m6/5OWlsayZctkpRYhcujzzz+nSJEiTJo0Se1S8h0JvgLE39+f1NRUVq5cmelz8vqxht27d1OuXDmcnJzy7JpCFESGhoasW7eO9evX6+SOK7pMhjoLmAsXLtCqVSv+/vtvypYt+87jHz58SLVq1fJs0ep27drx0Ucfyf09IbTkjz/+oFu3bpw6dQpbW1u1y8kXpMdXwNStW5d+/foxduzYTB1fpkwZ6tSpw2+//ZbLlcHNmzcJCQnBy8sr168lhL748MMPGT9+PD179iQ5OVntcvIFCb4CaMqUKfzxxx+Znu6cV8Ody5Ytw8/PT2e2QxKioBg7dixlypTh008/VbuUfEGGOguo3bt3M3LkSC5cuICZmdlbj71+/Tpubm7cu3cv11Z/T0xMpFKlSpw4cYKqVavmyjWE0GdPnz7FycmJuXPn0q1bN7XL0WnS4yugPDw8eP/995kxY8Y7j61evTrFihXjzJkzuVbP5s2badCggYSeELnE0tKSTZs2MWTIEG7evKl2OTpNgq8Amz9/PgEBAVy5cuWdx+b2cKesyylE7mvYsCGTJ0/G09OT58+fq12OzpLgK8DKly/P1KlTM/VsX26u4nL27Fnu37+Ph4dHrrQvhPg/w4cPx97entGjR6tdis6S4CvghgwZQlJSEqtXr37rcY0bN+bBgwfcvn1b6zUsXboUf39/jIyMtN62EOJlBgYGrFixggMHDrBhwwa1y9FJMrlFD5w7dw53d3cuXrxImTJl3njcgAEDqFOnDqNGjdLataOjo6lcuTJXr17N1HOFQgjtOH/+PK1ateLYsWPUqFFD7XJ0ivT49EC9evXw8fFh3Lhxbz0uN+7zrV27lnbt2knoCZHHHB0dmTlzJp6enjx79kztcnSK9Pj0RHx8PLVq1WLVqlW0aNHitcc8e/YMa2tr7ty5Q8mSJXN8TUVRcHBwIDAwkGbNmuW4PSFE1iiKgq+vL8bGxvzwww9ql6MzpMenJ4oWLcrixYsZMmTIG2d7FSlSRKuLVv/222+YmJjQtGlTrbQnhMgaAwMDli5dysmTJ1m1apXa5egMCT490qFDB+rUqcPMmTPfeIw2hzszHmGQzWaFUI+5uTmbN29mwoQJ/P3332qXoxNkqFPPhIeHU69evTfe8H748CHVq1fnwYMHmJqaZvs6ERER1K5dm9DQUIoVK5aTkoUQWrBu3Tq+/vprTp8+rfc/k9Lj0zMVKlRg8uTJDBkyhNd95ilTpgy1atXK8aLVgYGB9OrVS+9/wITQFX369KFZs2YMHjz4tT/7+kSCTw8NGzaMhIQE1qxZ89qv53S4MyUlheXLl8tms0LomIULF3L58mWWLVumdimqkqFOPXX27FnatWvHpUuXKF269Etfu3btGi1atCAsLCxb9+e2bdvG/PnzOXr0qLbKFUJoyfXr1/nwww/59ddf9XZDaOnx6SknJye8vb0ZP378K1977733KFq0aLYXrZZ1OYXQXdWrV2fx4sV4enoSHR2tdjmqkB6fHouPj6dmzZqsXbsWV1fXl742YcIETE1N+eqrr7LU5rVr13BxceHu3bsUKlRIi9UKIbRpxIgRhIeHs3XrVr2beS09Pj1WtGhRFi1ahL+/P0lJSS99Lbv3+QICAhgwYICEnhA6bs6cOdy7d48FCxaoXUqekx6foGvXrrz//vtMnjxZ81paWhrlypXj5MmTVK5cOVPtJCQkYGtry5kzZ7C1tc2tcoUQWnL79m0++OADgoOD+eCDD9QuJ89Ij0+wcOFCFi1axPXr1zWvGRkZ0aFDhyxtVbRx40acnZ0l9ITIJypXrkxgYCA9e/bk8ePHapeTZyT4BBUrVmTixImvPNuXleFORVFkUosQ+VCnTp3w8vLCx8fnnft2FhQSfAKAjz/+mJiYGIKCgjSvtW7dmpCQEJ4+ffrO80+fPk10dDTu7u65WaYQIhfMmDGD6Ohovv32W7VLyRNyj09onDlzhvbt23Pp0iVKlSoFgIeHB9WqVeP+/fv4+fnRrl27157br18/ateu/c6tj4QQuiksLIwGDRqwadMmmjdvrnY5uUqCT7xk5MiRxMfH07VrV/r37/9Sb2/58uX4+fm9cs7jx4+xt7fnxo0bmsAUQuQ/e/fuZeDAgZw9e/atm1bndxJ84iVhYWHUqFGDlJQUkpOTMTQ0JD09neLFi7N//34aNWr0yjlz587lwoULb1wCTQiRf0yaNIkTJ06wd+9ejIyM1C4nV0jwCY1r167RpEkT4uPjSUlJoWjRohgZGRETE4ORkRFPnz59ZdHp9PR0qlevzvr162ncuLFKlQshtCUtLY3WrVvj4uLClClT1C4nV8jkFqFRtmxZGjdujImJCfBiselvvvmGwoULY2xs/NqdFvbv30+JEiVe2xMUQuQ/RkZGbNiwgeXLl3PgwAG1y8kVEnxCw8LCgj179rBlyxasrKxISkri0aNH7Nq1Cx8fHyIjI7l9+zY3btzg9u3bREZGsnr1aoYOHap3Sx4JUZBZW1uzbt06+vbtyz///EPv3r1ZvXq12mVpjQx1itdKTEykb9++dO7cGWdnZ2JiYgBees7PwMCApKQkSpYsiY2NDebm5mqVK4TIBSNGjCAwMJDU1FTc3d3ZvXu32iVphQSfeKOoqCjCwsIy9VCroaEhNjY2WFlZ5UFlQojctm3bNvr06UNiYiIA5cqVIyIiQuWqtEOGOgUAH374IX/99Rfw4mHWPn36ZDr04MUkl7CwMKKionKzzJckJSVRo0YNHj58mGfXFEJfJCcnU6hQIYoUKQLAw4cPSUhIULkq7ZDg01Ft2rR5adHoDMHBwVhbW5Oampqtdu3s7F65Yb1jxw6KFSvG+++/D7x4lm/s2LFZXr4oI/yy+8Nx584dDAwMMv29mZqa0r9/f2bNmpWt6wkh3qxXr17cv3+fr776iqJFi5KWlsbhw4c1X09JSXntff+UlBT1is4kCT4d1a9fP4KCgvjvSHRQUBDe3t4YGxtr7VoBAQH07dtX8/fIyMhsr9mXnp5OZGSktkp7p969e7NmzZpXtlUSQuScmZkZY8aMISoqitGjR1OlShUSEhK4efMmf//9NxERETx58oSYmBiePHlCREQEf//9Nzdv3tTp3qEEn47q0qULT5484dixY5rXnj59ys6dO/Hx8WH37t3UrFmTYsWKUaFCBebMmaM5bufOndSrVw8LCwucnZ25cOECAH379uXu3bt07NiRokWL8u2335KcnMyhQ4dwcXEBXnyK+/bbb5k0aRIAERERNGjQgF9++YX27dvj5ubGli1buHTpEr169cLV1fWlHteOHTvo3r07w4cPp0SJEtSoUYODBw9qvv7fHufUqVPp06cPgGaZJAsLC4oWLcrx48cB+OGHH3BwcMDS0pI2bdoQGhqqOd/GxgZLS0tOnDihnTdeCPGKwoUL891331G6dGmuX79OdHQ0iqK88sE847Xo6GiuX7+ep7c+skKCT0eZmZnh5eXF2rVrNa9t2rSJGjVq4OjoyIABA1i2bBlxcXFcvHiRFi1aAHD27Fn69+/PsmXLePz4Mf7+/nTq1ImkpCSCgoKoVKkSO3bsID4+ngkTJvDPP/9oJqYAb9ya5OLFi2zbto2ZM2fy3Xff8cMPP7BkyRI2bdrEgQMHOHPmzEvHlilThkePHjFt2jS6devGkydP3vk9Hz16FIDo6Gji4+Np0qQJ27dvZ8aMGWzbto2oqCiaNWvGRx999NJ5Dg4OnD9/PmtvsBAiS7Iy2Q3+79bH+PHjNR9udYUEnw7z9fVl8+bNmllVa9euxdfXFwATExMuX75MbGwslpaWODk5ARAYGIi/vz+NGzfGyMgIX19fTE1N39gjio6OfunB9MTExFc+xQEMHDgQU1NTPvjgA8zMzGjTpg0lS5akTJky1KtXj2vXrmmOtbS0pG/fvpiYmNCzZ0/ee+89du3ala33YNmyZXz++ec4ODhgbGzM//73P86dO/dSr69YsWJER0dnq30hxOvZ2dlhZmZG0aJFKVq0KLa2tsycOTNLbaSnpxMbG5vtOQm5RYJPhzVt2hQrKyuCg4O5desWp0+fpnfv3gBs3bqV3bt3Y2tri4uLi2ZYMDQ0lLlz52JhYaH57969e2+chmxpaUlcXJzm72lpaa89rmTJkpo/m5qavvT3woUL8+zZM83fy5Qp89KnQltb22xPgw4NDWXkyJGa76VkyZIoikJ4eLjmmLi4OCwsLLLVvhDizTJGh86fP8+xY8f49NNPs9yGoiiaD++6QoJPx/n4+LB27VqCgoJwd3enbNmyADRs2JDg4GAePnxIly5d8PLyAv5vU9no6GjNf8+ePdMMD/53hZVq1aq9FCTaWJT24cOHGBr+3z+tu3fvUr58eQDMzc1fCsl/T4R53eovFStWZNmyZS99P4mJiTg7O2uOuXLlCo6OjjmuWwjxqpSUFM0CFvAiDAcMGMD8+fNxc3OjU6dO/PHHH5qvh4eHM3jwYJo3b86wYcOIjo4mJSVFp2Z7SvDpOB8fHw4cOEBgYKBmmDM5OZn169cTExODiYkJxYsX1wTWoEGDCAgI4OTJkyiKQkJCArt27dL06sqWLcutW7c07ZuYmNCqVSuOHDkCvLi3mNPlx54+fcr69etJSUlh8+bNXLlyBQ8PDwDq1avHxo0bSUlJISQkhC1btmjOs7KywtDQ8KX6hgwZwsyZM7l06RIAMTExbN68WfP18PBwnjx5wgcffJCjmoUQr/e6+/4XL17E1taWAwcO4OPjw1dffaW5RfLFF19Qo0YNDhw4wMCBAzW3Od40f0ANEnw6zs7ODmdnZxISEujUqZPm9aCgIOzs7ChevDgBAQGsW7cOgAYNGhAYGMjHH3+MpaUl9vb2L62x9/nnn/P1119jYWGhmQnq7++v2XldG/vp1a5dm/v371O6dGkmTpzIli1bNO1+9dVX3Lx5E0tLS6ZMmaIZugUoUqQIEydO5MMPP8TCwoITJ07QtWtXPv30U3r16kXx4sWpXbs2e/bs0ZyzYcMGzX1MIYR2denSherVq+Pi4oKrqys///wz8GIVl65du2JkZESHDh149OgRjx8/JjIyksuXLzN06FAKFSqEk5MTzZo1A9Cp4U5ZskwAL+4nLlq0iPfff5+bN29me7LIjh072LlzJyEhIdot8DWSkpJwdHTk6NGjBXrTTCHUYGdnx4oVK7Czs3tlqHP79u2sXLlS81qDBg34+eefiY6OZvTo0S89svT999/z4MEDFi5ciL29fZ5+D2+ivaegRb72+++/a/5sbW1NbGxsth5iNzAwoFChQtos7Y1MTU25evVqnlxLCH2Vlfv+pUuXJi4ujsTERMzMzIAX9/ENDAx0alNbGeoUrzA3N8fGxualCSqZYWhoSMmSJbN8nhBCd2Xlvn+5cuVwcHBg2bJlpKSkcO7cOc0iHBlBqAukxydeK2OXhazuzjBixAhGjBiR2+UJIfJAx44dMTIy0vwOaNy4sWaVpzf5+uuvmTp1Ki1atKBOnTp4eHgQHx+vlfkD2iL3+MRbJSQkEBkZ+cb9+ABKlCiBtbW17McnRAGVk/v+8GIZwqpVq2qvoByS4BOZkpKSwuPHj0lMTCQtLQ0jIyPMzMwoVaoUJiYmapcnhMhFCQkJXL9+PVv3/Q0NDalevbpOfTCW4BNCCPFOWV2rE3R3g2qZhSCEEOKdrKyssjTpTVdDD6THJ4QQIgsKwn1/CT4hhBBZlp/v+0vwCSGE0Ctyj08IIYRekeATQgihVyT4hBBC6BUJPiGEEHpFgk8IIYRekeATQgihVyT4hBBC6BUJPiGEEHpFgk8IIYRekeATQgihVyT4hBBC6BUJPiGEEHpFgk8IIYRekeATQgihVyT4hBBC6BUJPiGEEHpFgk8IIYRekeATQgihVyT4hBBC6BUJPiGEEHpFgk8IIYRe+X9RSYUvIHP1wwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "build_graph(metrics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "incident-belle",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>eval</th>\n",
+       "      <th>impute</th>\n",
+       "      <th>count</th>\n",
+       "      <th>mean</th>\n",
+       "      <th>std</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>acc</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>30</td>\n",
+       "      <td>0.643794</td>\n",
+       "      <td>0.064808</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>acc</td>\n",
+       "      <td>median</td>\n",
+       "      <td>30</td>\n",
+       "      <td>0.660816</td>\n",
+       "      <td>0.056079</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>auroc</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>30</td>\n",
+       "      <td>0.687251</td>\n",
+       "      <td>0.081875</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>auroc</td>\n",
+       "      <td>median</td>\n",
+       "      <td>30</td>\n",
+       "      <td>0.705123</td>\n",
+       "      <td>0.079892</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "    eval  impute  count      mean       std\n",
+       "0    acc    mean     30  0.643794  0.064808\n",
+       "1    acc  median     30  0.660816  0.056079\n",
+       "2  auroc    mean     30  0.687251  0.081875\n",
+       "3  auroc  median     30  0.705123  0.079892"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_impute = perturbation_stats(df_metrics, 'eval', 'impute')\n",
+    "df_impute"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "municipal-pregnancy",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mean_means = df_impute[df_impute['impute'] == 'mean']['mean'].to_numpy()\n",
+    "mean_stds = df_impute[df_impute['impute'] == 'mean']['std'].to_numpy()\n",
+    "median_means = df_impute[df_impute['impute'] == 'median']['mean'].to_numpy()\n",
+    "median_stds = df_impute[df_impute['impute'] == 'median']['std'].to_numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "roman-syracuse",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXQAAAEICAYAAABPgw/pAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAAjoUlEQVR4nO3deZxU1Zn/8c+XRgTUoChuLIKKCyoQBMQdI45odNBIFNw1ys8kaEwmjiRkIonR0YnOGJeEIQYdt2BcQxTjMhNi4hJBBRXXFhFaXBC3oBAFnt8f9zQWRXV3dVtNw+3v+/XqV9e959x7n3vr1lOnzr11ShGBmZmt/9q0dABmZlYZTuhmZjnhhG5mlhNO6GZmOeGEbmaWE07oZmY54YRujSZpnqRhLR1HpeV1vxpL0n2STmnpOKzxnNABSdMlvS9pw5aOJS8kTZAUkgaXmH9Tifohacf0eLqkZZKWSHpX0p2Stimq30fSVEkfSvq7pD9J2qeoTru0vVckfZwS9mRJPZthlwu3O1RSTXNuo55tT5d0RiPqr/F8RMRhEfE/zRBbN0l3pOf0Q0nPSjo1lfVM50DbL7iNVv2m3OoTenpx7w8E8M9redtf6ORdV0kScBLwHtDUlt7YiNgY2BHYGLisYP07AI8AzwK9gG2Bu4AHJO1dsI7byZ7T44FOQD/gSeDgJsZkX8yNwAJgO2Bz4GTg7XIXzuvrpaIiolX/AT8mSw7/CdxTVNYduBNYBCwGri4oOxN4Afg78DwwIM0PYMeCetcDP0uPhwI1wPnAW2Qn+GbAPWkb76fH3QqW7wxcByxM5Xen+c8BRxbU2wB4F+hfYh8b2sZ04MJ0HP4OPABsUVB+EvB6OgbjgXnAsHqO6QHAUuDEtEy7grIJwE0llll13FI8ZxSUfQuYUzB9IzCtxDp+BTycHg9LMXRvxLkwD/hBej7fT8e9fROO91Cgpuj4/gx4FFgC/IEsod0MfATMAHoWHYtzgLlpGz8H2pQ6fkDPVL8tcBGwAliWtnN1qvMLskT6Edkb2v5p/nDgU+CzVH928fEna/T9KD3/7wA3AJ2Ktn0KMD/FOr6e47uk1PFKZfPTupakv72BU8nOyf8iaxz8DNgB+L90Xr2bjuGmBefFyvS8LwH+Nc0fko79B8BsYGjBdnsBD5Od9w8B19QeX+Be4OyiOJ8BjmrpvFXnMW7pAFr6D6gmSxh7phN7qzS/Kj35/wVsBLQH9ktlXwfeAAYBImtFbpfKGkroy4FLgQ2BDmQv7GOAjsAmwG2kpF1wUt1KlpQ3AA5M8/8VuLWg3gjg2Tr2saFtTAdeBXZKMU0HLkllfdKL44AU83+mfagvof8G+F2KdzHwtYKyCTQioafYHwJ+X1D3LeC0Eus4iCyhdQQuAf7cyHNhHlni7k72RvpIwXPXmOM9lDUTejVZMupE9obxMtmbTluyJHld0bH4U4qhR6pbezxWO34UJPTiY1dQ58R0HNsC/5KOX/tS6ytx/E9PsW9P9knpTuDGom3/Op03/YB/ALvWcVweSsd0FNCjqGy1/UjzTk3n2tkp9g5kr7VDyM7FLmTJ+Iqi53BYwXRXsnPwcLI3p0PSdJdU/hjZp792wH5kb3q1Cf1Y4G8F6+pHUQNlXftr8QBadOezJ/AzUmsUeBH4bnq8N1mLtm2J5e4HvlPHOhtK6J/WvpjqWL4/8H56vA1Zi2OzEvW2JWtVfClN305qkZSx36u2kaanAz8qmP4W8Mf0+MfAlIKyjdI+lEzoZMn0I1IrBvhvVk/GEygvoX8CfJjmzypMAOlFPrzEOnZJ9buSJZkppWKs57jMA84qmD4ceLWxx5vSCX18wfTlwH0F00cCs4qOxfCC6W8B/1vq+FFGQi8R3/tAv7qeD1ZP6P8LfKugbGey10zbgm0Xftp7AhhVx3Y3I3ujnUP2xjsLGFRqP9K8U4H5DezLUcDTRc9hYUI/n/QGVDDvfrJPFT3SudSxoOwmPk/oG5J9Muidpi8DftmYc2pt/7X2PvRTgAci4t00fQuf9/l2B16PiOUllutO1qJtikURsax2QlJHSf8t6XVJH5G1ODaVVJW2815EvF+8kohYSNbaOUbSpsBhZB8/19DANmq9VfD4E7LWGGSJbEHBdj8ma6XU5WiyF8m0NH0zcJikLml6OVnLvTC+2unPCmafExGdgL5kiaBbQdm7ZG92xWrfAN9PMZaq05AFBY9fJ9v/Rh3vOhT2FS8tMb3x6tVLx9EUkv5F0gvpQuQHZJ8Stihz8W3T9gtjaQtsVTCvrnNnNRHxfkSMi4jd0vKzgLvTNZe6FB4HJG0paYqkN9K5fFMD+7Id8HVJH9T+kTXktkn79l5EfFJqexHxD7JPmidKagOMJuvWWWe12oQuqQPZR6oDJb0l6S3gu0A/Sf3IntgedVyIWUD28bmUT8haqbW2LiqPoul/IWv17BURXyLr2oCsK2cB0DklkFL+h+zj9NeBxyLijTrq1beNhrxJ9saSLSB1JPv4XpdTyF7Q89MxvY0sgY9O5fPJWmOFepG12NaIPyKeJes7vabghf8Q2T4XO5bsOHyS6gyW1K1Evfp0L3jcg+zaRa1yj3cl1BXHxzTi/JK0P1kr9ViyT3qbkn3yUan6JSwkS4qFsSynERczS0mNqMvIkmrneuIonv/vaV7fdC6fyOrncXH9BWQt9E0L/jaKiEvIzu3O6Zyu1b1o+f8BTiC7kP5JRDxW3h62jFab0Mk+qq0g6yPun/52Bf5CdvX9CbIn/BJJG0lqL2nftOy1wPcl7anMjpJqT/pZwPGSqiQNBw5sII5NyFpoH0jqDFxQWxARbwL3Ab+UtJmkDSQdULDs3cAA4Dtk/bCN3kYZbgeOkLSfpHbAT6njvJHUlezEP4LPj2k/smsGtZ98/gjsLOmktD+dgYuB2+v4NATZi2pLPr8L6SfAPpIuktRZ0iaSziZ73s4HiIiHgAeBu9Lz1DbVO0vS6fXs77fT7XWdgR+SXb+odTflHe9KOC89593T9mrjmAUcIKmHpE5kF3ELvU3W311rE7IEvAhoK+nHwJeK6vdMLdBSfgt8V1IvSRuTPVe31vNc1UnSpZJ2r30ugG8C1RGxOMW3sij2UjYhu6bzQTrfzisqL97/m4AjJR2aXpPt022l3SLidWAmMEHZLa57k3V/rZIS+EqybrJ1unUOrTuhn0J2IWp+RLxV+wdcTfaOLLInd0eyVmUNcBxARNxGdkfBLWT9qneTtTIge/EdSXZF/YRUVp8ryC72vAs8TpbwCp1E1hXxItldBufWFkTEUuAOshbunV9gG3WKiDnAt8n29U2y7oy67rE+iawv+IGiY3ol0FfS7hHxDlnf9P9L+/McWYvxm/XE8Glax7+l6VfIPjb3I+szfZPsou+hEfFIwaIjybp+bk3beA4YSNZ6r8stZHf5zE1/PyuIo9zjXQm/J7sjZRbZhfHfpBgeJNufZ1L5PUXL/QIYqex7FVeS9RffR3Zh9XWyO2AKuzFuS/8XS3qqRByTyRLZw8Brafmzm7hPHcluL/2A7NhuR3qTTp+qLgIeSV0jQ+pYx0/I3lQ/JDsuxc/DvwM/Suv4fkQsILuA/UOyN40FZG8CtbnvBLLrZYvJnutbyS7sFroB2IPszWGdptTZb+up1OLaKSJObOlYWoO1cbwlBdmFuOrm2oaVJulW4MWIuKBg3snAmIjYr+UiK09rbqGv91K3wDeASS0dS2vg450/kgZJ2kFSm9RFOoKCT9Wpf/1brCfPuRP6ekrSmWQfH++LiIdbOp688/HOra3JbtNcQtat982IeBpA0qFk3TRvk3XFrfPc5WJmlhNuoZuZ5USLDXazxRZbRM+ePVtq82Zm66Unn3zy3YjoUqqsxRJ6z549mTlzZktt3sxsvSTp9brK3OViZpYTTuhmZjlRVkKXNFzSS5KqJY0rUd5J0h8kzZY0R9JplQ/VzMzq02BCTyPyXUM2ulwfYLSkPkXVvg08HxH9yIYOvTyN+2FmZmtJOS30wWQD6MxNY2pMIfs2VaEANkmj4W1MNoZwowfvMTOzpisnoXdl9cF8atK8QleTjVS4kOx3Hr8TESuLVyRpjKSZkmYuWrSoiSGbmVkp5ST0UmNmF3+99FCyUeG2JRsy9WpJXyqqQ0RMioiBETGwS5eSt1GamVkTlZPQa1h90PdurD7oP8BpwJ2RqSYbZnOXyoRoZmblKCehzwB6pwHu25H9wOvUojrzyX7YAElbkf06ztxKBmpmZvVr8JuiEbFc0liygfKrgMkRMUfSWal8InAhcL2kZ8m6aM4v+J1OM7N1xtChQwGYPn16i8bRHMr66n9ETOPzH/2tnTex4PFC4J8qG5qZmTWGvylqZpYTTuhmZjnhhG7WSg0dOnRVf7LlgxO6mVlOOKGbmeWEE7qZWU44oZuZ5YQTuplZTjihm5nlhBO6mVlOOKGbmeWEE7qZWU44oZuZ5YQTuplZTjihm5nlhBO6mVlOOKFbWTwyn9m6r6yELmm4pJckVUsaV6L8PEmz0t9zklZI6lz5cM3MrC4NJnRJVcA1wGFAH2C0pD6FdSLi5xHRPyL6Az8A/hwR7zVDvC3OLVUzW1eV85uig4HqiJgLIGkKMAJ4vo76o4HfViY8M8utCZ1aZrvzPm7Z7QNM+LBZVltOl0tXYEHBdE2atwZJHYHhwB11lI+RNFPSzEWLFjU2VjMzq0c5CV0l5kUddY8EHqmruyUiJkXEwIgY2KVLl3JjNDOzMpST0GuA7gXT3YCFddQdhbtbzMxaRDkJfQbQW1IvSe3IkvbU4kqSOgEHAr+vbIhmZlaOBi+KRsRySWOB+4EqYHJEzJF0ViqfmKoeDTwQER83W7RmOdNz3L0ttu235i5u0RjmtW+RzeZaOXe5EBHTgGlF8yYWTV8PXF+pwMzMrHH8TVEzs5xwQjczywkndDOznHBCNzPLibIuito6xF+XNrM6uIVuZpYTTuhmZjnhhG5mlhNO6GZmObFeXhT116XNzNbkFrqZWU44oZuZ5YQTuplZTjihm5nlxHp5UdTMrKmmn7pRS4fQbNxCNzPLCSd0M7OcKCuhSxou6SVJ1ZLG1VFnqKRZkuZI+nNlwzQzs4Y02IcuqQq4BjgEqAFmSJoaEc8X1NkU+CUwPCLmS9qymeI1M7M6lHNRdDBQHRFzASRNAUYAzxfUOR64MyLmA0TEO5UO1FpWni8ktVZbH39JS4dgFVZOl0tXYEHBdE2aV2gnYDNJ0yU9KenkSgVoZmblKaeFrhLzosR69gQOBjoAj0l6PCJeXm1F0hhgDECPHj0aH62ZmdWpnBZ6DdC9YLobsLBEnT9GxMcR8S7wMNCveEURMSkiBkbEwC5dujQ1ZjMzK6GchD4D6C2pl6R2wChgalGd3wP7S2orqSOwF/BCZUM1M7P6NNjlEhHLJY0F7geqgMkRMUfSWal8YkS8IOmPwDPASuDaiHiuOQM3M7PVlfXV/4iYBkwrmjexaPrnwM8rF5qZmTWGx3JpJN/qZWbrKn/138wsJ5zQzcxywgndzCwnnNDNzHLCCd3MLCec0M3McsIJ3cwsJ5zQzcxywgndzCwnnNDNzHLCCd3MLCec0M3McsIJ3cwsJ5zQzcxywgndzCwnnNDNzHLCCd3MLCfKSuiShkt6SVK1pHElyodK+lDSrPT348qHamZm9WnwJ+gkVQHXAIcANcAMSVMj4vmiqn+JiCOaIUYzMytDOS30wUB1RMyNiE+BKcCI5g3LzMwaq5yE3hVYUDBdk+YV21vSbEn3Sdqt1IokjZE0U9LMRYsWNSFcMzOrSzkJXSXmRdH0U8B2EdEPuAq4u9SKImJSRAyMiIFdunRpVKBmZla/chJ6DdC9YLobsLCwQkR8FBFL0uNpwAaStqhYlGZm1qByEvoMoLekXpLaAaOAqYUVJG0tSenx4LTexZUO1szM6tbgXS4RsVzSWOB+oAqYHBFzJJ2VyicCI4FvSloOLAVGRURxt4yZmTWjBhM6rOpGmVY0b2LB46uBqysbmpmZNYa/KWpmlhNO6GZmOeGEbmaWE07oZmY54YRuZpYTTuhmZjnhhG5mlhNO6GZmOeGEbmaWE07oZmY54YRuZpYTTuhmZjnhhG5mlhNO6GZmOeGEbmaWE07oZmY54YRuZpYTZSV0ScMlvSSpWtK4euoNkrRC0sjKhWhmZuVoMKFLqgKuAQ4D+gCjJfWpo96lZL89amZma1k5LfTBQHVEzI2IT4EpwIgS9c4G7gDeqWB8ZmZWpnISeldgQcF0TZq3iqSuwNHAROohaYykmZJmLlq0qLGxmplZPcpJ6CoxL4qmrwDOj4gV9a0oIiZFxMCIGNilS5cyQzQzs3K0LaNODdC9YLobsLCozkBgiiSALYDDJS2PiLsrEaSZmTWsnIQ+A+gtqRfwBjAKOL6wQkT0qn0s6XrgHidzM7O1q8GEHhHLJY0lu3ulCpgcEXMknZXK6+03NzOztaOcFjoRMQ2YVjSvZCKPiFO/eFhmZtZY/qaomVlOOKGbmeWEE7qZWU44oZuZ5YQTuplZTjihm5nlhBO6mVlOOKGbmeWEE7qZWU44oZuZ5YQTuplZTjihm5nlhBO6mVlOOKGbmeWEE7qZWU44oZuZ5YQTuplZTjihm5nlRFkJXdJwSS9JqpY0rkT5CEnPSJolaaak/SofqpmZ1afB3xSVVAVcAxwC1AAzJE2NiOcLqv0vMDUiQlJf4HfALs0RsJmZlVZOC30wUB0RcyPiU2AKMKKwQkQsiYhIkxsBgZmZrVXlJPSuwIKC6Zo0bzWSjpb0InAvcHqpFUkak7pkZi5atKgp8ZqZWR3KSegqMW+NFnhE3BURuwBHAReWWlFETIqIgRExsEuXLo0K1MzM6ldOQq8BuhdMdwMW1lU5Ih4GdpC0xReMzczMGqGchD4D6C2pl6R2wChgamEFSTtKUno8AGgHLK50sGZmVrcG73KJiOWSxgL3A1XA5IiYI+msVD4ROAY4WdJnwFLguIKLpGZmthY0mNABImIaMK1o3sSCx5cCl1Y2NDMzawx/U9TMLCec0M3McsIJ3cwsJ5zQzcxywgndzCwnnNDNzHLCCd3MLCec0M3McsIJ3cwsJ5zQzcxywgndzCwnnNDNzHLCCd3MLCec0M3McsIJ3cwsJ5zQzcxywgndzCwnykrokoZLeklStaRxJcpPkPRM+ntUUr/Kh2pmZvVpMKFLqgKuAQ4D+gCjJfUpqvYacGBE9AUuBCZVOlAzM6tfOS30wUB1RMyNiE+BKcCIwgoR8WhEvJ8mHwe6VTZMMzNrSDk/Et0VWFAwXQPsVU/9bwD3lSqQNAYYA9CjR48yQzSzPPqs3abUDDifZZ22B9TS4axdL7zQYJX27dvTrVs3Nthgg7JXW05CL3Wko2RF6SCyhL5fqfKImETqjhk4cGDJdZhZ61Az4Hw22X4gPTdqi9TKEvq2u9ZbHBEsXryYmpoaevXqVfZqy+lyqQG6F0x3AxYWV5LUF7gWGBERi8uOwMxapWWdtmfz1pjMyyCJzTffnGXLljVquXIS+gygt6RektoBo4CpRRvvAdwJnBQRLzcqAjNrpeRkXo+mHJsGu1wiYrmkscD9QBUwOSLmSDorlU8EfgxsDvwyBbE8IgY2OhozM2uysu5Dj4hpEbFTROwQEReleRNTMicizoiIzSKif/pzMjeziti4977Nvo2Lr/xNk+rt88+nNkM0TedvippZq3fxVZObVO/Rqdc3QzRN54RuZuuF6Y/O5MBjzuDY/3c+O+13FOMuvpKb75zG4K+exB4HH8ur87K7q0899wLOOv8i9j/6dHba7yjuefBhAK6/dSpjx1+yan1HnHwO0x+dybiLr2Tpsn/Q/5BRnDB2PABHnf499hx+PLsdNJJJN90BULJe7aeHiOC8C/+L3b/ydfY4+Fhu/f39q2IeOvJMRp55Hrsc8DVOGDueiOa7wa+c2xbNzNYJs59/mRem30HnTTux/T5Hcsboo3ji3hv5xbW3cNXkKVzx0/MAmFezkD/fcS2vzqvhoK+PoXr/ur86c8kPz+Hq625l1oNTVs2bfPkFdN6sE0uXLmPQV0/imMMPLlmv1p3T/o9Zc15m9oNTePe9Dxh0+EkcMGQAAE8/9xJz/u82tt26C/uOOI1HZsxiv64DKnxkMm6hm9l6Y1C/3dhmqy5suGE7dtiuG/904N4A7LHLjsyreXNVvWOPPIQ2bdrQe/sebL9dV16snteo7Vw5+bf0G3YcQ448hQUL3+aV1+bXW/+vTzzN6KMOpaqqiq26bM6BQwYwY/bzAAzuvxvdtt2KNm3a0H+3nZm3YI27vivGLXQzW29s2O7zb022adOGDdu1W/V4+fLlq8qKb/mTRNu2Vaxc+Xl3x7J/fFpyG9MfnclDf3mCx/5wPR07dGDoyDPrrFurvm6UwpirqtqwfPmKetf1RbiFbma5c9s9D7Fy5UpenbeAua+/wc47bEfP7tsya85LrFy5kgVvvMUTs+asqr/BBm357LPPAPjw70vYrNMmdOzQgRerX+Pxp54tWa/QAUMGcOvUB1ixYgWLFr/Pw397isH9d2v+HS3iFrqZ5c7O22/HgcecwduL3mPiJT+kffsN2XdQf3r16MoeBx/L7jvvwIA9dllVf8wJX6PvsOMYsMeuTL78AibeeDt9hx3Lztv3ZMiAPUrWu/nqi1bNP/qwr/DYk8/Q75BRSOI/xn+HrbfcotFdPV+UmvOKa30GDhwYM2fObNKyPcfdW+Fo1h/z2h/f0iG0nAkftnQEFdeaz+X7RrRl1+22rPh6Tz33Ao4Ytj8jjxhW8XVXzLZfLqvaCy+8wK67rj7ui6Qn6/quj7tczMxywl0uZpYr11/xk5YOocW4hW5mlhNO6GZmOeGEbmaWE07oZmY54YuiZrZO6HllZb8SP++cbSu6vvWBW+hmZjnhhG5mrdK8BQvZ5YCvccb3f8ruX/k6J4wdz0MP/419R5xG731H8MTTz/HxJ0s5/XsTGHT4iXz5n0bz+/unr1p2/6NPZ8ChxzPg0ON5dMZsYO0Pl1usrC4XScOBX5D9BN21EXFJUfkuwHXAAGB8RFxW6UDNzCqtet4CbvvvS5n0Hz9i0OEncsvd9/HXuycz9YE/c/FVk+nTuxdf2XcQk/9zAh98+HcGf/Ukhu2/F1tusRkP/vZXtG+/Ia/Mnc/ob/+AmffdDNQxXO7g8r4Z+kU1mNAlVQHXAIcANcAMSVMj4vmCau8B5wBHNUeQZmbNoVf3bdlj194A7LbTDhy832AkZcPxLlhIzZtvM/XBh7ls4o1ANkLj/DfeZNutujB2/KXMev5lqtq04eW5nw+vWztcLrBquNx1JqEDg4HqiJgLIGkKMAJYldAj4h3gHUlfbZYozcyawYYbtlv1eI3heFesoKqqDXdM+jk779hzteUmXD6RrbpszuwHp7By5Urab7/35+tci8PlFiunD70rsKBguibNazRJYyTNlDRz0aJFTVmFmdlac+iBe3PVdVNW9YM//dyLAHz40RK22XIL2rRpw4133MuKFWsvadennBa6SsxrUi9/REwCJkE22mJT1mFm+bQu3mb4b+eeybkXXEbfYccREfTstg333HAl3zrlWI4Z831uu+dBDtp3EBt17NDSoQJlDJ8raW9gQkQcmqZ/ABAR/16i7gRgSTkXRT18btN4+Nx8ac3ncnMNn7teaMHhc2cAvSX1ktQOGAVMLSsaMzNbaxrscomI5ZLGAveT3bY4OSLmSDorlU+UtDUwE/gSsFLSuUCfiPio+UI3M7NCZd2HHhHTgGlF8yYWPH4L6FbZ0MzMrDH8TVEzs5xwQjczywkndDOznPDwuWa2bpg0tLLrGzO9suurx9CRZ3LZv32Xgf36cPhJZ3PL1RezaadN1tr2azmhm5lV0LQbr2qxbbvLxcxapS8yfO7SpcsY9c1x9B12LMeddT5Ll/1j1Xp77vVV3n3vfQCOOv177Dn8eHY7aCSTbrpjVZ2NN96Y8ePH069fP4YMGcLbb79dkX1yQjezVqt63gK+843RPPPQrbxY/dqq4XMv+/F3ufiqyVz0i2v5yr6DmDHtJv502yTOu/AKPv5kKb+64XY6dmjPMw/9jvHnfIMnn3mh5PonX34BT/7xFmZOu4krJ09h8XsfAPDxxx8zZMgQZs+ezQEHHMCvf/3riuyPu1zMrNVq6vC5D//tKc45fRQAffvsRN+0jmJXTv4td933JwAWLHybV16bz+adN6Vdu3YcccQRAOy55548+OCDFdkfJ3Qza7WaOnwugFRq3MLPTX90Jg/95Qke+8P1dOzQgaEjz2TZPz4FYIMNNli1fFVVFcuXL6/I/rjLxcysDnUNn3vAXgO4+a77AHjuxWqeeeGVNZb98O9L2KzTJnTs0IEXq1/j8aeebfZ43UI3s3XDWrzNsFx1DZ/7zZNHctr3JtB32LH077Mzg/vvtsayw4fuw8Qbb6fvsGPZefueDBmwR7PH2+Dwuc3Fw+c2jYfPzZfWfC57+NyGNcfwuWZmth5wQjczywkndDNrIUFLdfmuD5pybJzQzaxFtP9wLos/Xu6kXkJEsHjxYtq3b9+o5XyXi5m1iG5PXUoN57Oo0/aU/i36HPuw9DdLC7Vv355u3Rr3u0FO6GbWIjb49AN6Pf6Dlg6jZTTTHVtldblIGi7pJUnVksaVKJekK1P5M5IGVD5UMzOrT4MJXVIVcA1wGNAHGC2pT1G1w4De6W8M8KsKx2lmZg0op4U+GKiOiLkR8SkwBRhRVGcEcENkHgc2lbRNhWM1M7N6lNOH3hVYUDBdA+xVRp2uwJuFlSSNIWvBAyyR9FKjojUEWwDvtnQcLeInrezCWc75XG6y7eoqKCehl9py8X1G5dQhIiYBk8rYptVB0sy6vvZrtj7xuVx55XS51ADdC6a7AQubUMfMzJpROQl9BtBbUi9J7YBRwNSiOlOBk9PdLkOADyPizeIVmZlZ82mwyyUilksaC9wPVAGTI2KOpLNS+URgGnA4UA18ApzWfCG3eu6ysrzwuVxhLTZ8rpmZVZbHcjEzywkndDOznHBCb0aSjpYUknZp6VjMKq34/JY0VNI9RXWulzQyPZ6ehhCZLWmGpP4F9TpJukHSq+nvBkmdCsp3kjQtDS/ygqTfSdpqLe3qesMJvXmNBv5KdmdQs0hDM5i1hKac3ydERD/gl8DPC+b/BpgbETtExA7Aa8C1AJLaA/cCv4qIHSNiV7LhRbpUYB9yxQm9mUjaGNgX+AbphJdUJekySc+mQczOTvMHSXo0tVyekLSJpFMlXV2wvnskDU2Pl0j6qaS/AXtL+nFq8TwnaZIkpXo7SnoorfcpSTtIulHSiIL13izpn9fWcbF8KHV+N9JjZN8mR9KOwJ7AhQXlPwUGStoBOB54LCL+UFsYEX+KiOeaGH5uOaE3n6OAP0bEy8B7aQTKMUAv4MsR0Re4Od3bfyvwndRyGQYsbWDdGwHPRcReEfFX4OqIGBQRuwMdgCNSvZuBa9J69yEbiuFa0m2l6SPtPmS3nZo1xlGseX43xnDg7vS4DzArIlbUFqbHs4DdgN2BJ79gvK2Cx0NvPqOBK9LjKWl6e2BiRCwHiIj3JO0BvBkRM9K8jwBSI7suK4A7CqYPkvSvQEegMzBH0nSga0Tclda7LNX9s6RrJG0JfA24ozYes0YodX7fU0fdwnujb5a0Edl3WmrfBESJoULqmW91cEJvBpI2B74C7C4pyE7eIGtllBoHp9RJu5zVP0EV/hbVstrWTOpf/CUwMCIWSJqQ6tb3jnAjcALZR+XTy9wtM6De8/sGYLOi6p1ZfQCuE4DZwCVkw3J/DZgDfFlSm4hYmbbRBugHvABsCRzYbDuUI+5yaR4jyYYT3i4iekZEd7KLPE8BZ0lqCyCpM/AisK2kQWneJql8HtBfUhtJ3cmGMS6lNtG/m/o1R8Kqln6NpKPSejeU1DHVvR44N9WbU7G9ttairvO7M9m5vCuApO3IkvKswoUj4jPgR8AQSbtGRDXwdJpX60fAU6nsFmAfSV+tLVT2ozt7NNserqec0JvHaOCuonl3ANsC84FnJM0Gjk9jzB8HXJXmPUiWpB8he5E8C1xG9mawhoj4APh1qnc32dg7tU4CzpH0DPAosHVa5m2yls91X3A/rXWq6/weBZwIXCdpFnA7cEZErPF7axGxFLgc+H6a9Q1gp3Rb4qvATmlebd0jgLMlvSLpeeBU4J0K79d6z1/9b4VSS/1ZYECpF5uZrZ/cQm9lJA0j6+a5ysncLF/cQjczywm30M3McsIJ3cwsJ5zQzcxywgndzCwnnNDNzHLi/wNY1WXaCOUZ+wAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fig, ax = plt.subplots()\n",
+    "\n",
+    "ind = np.arange(2)    # the x locations for the groups\n",
+    "width = 0.35         # the width of the bars\n",
+    "\n",
+    "ax.bar(ind, mean_means, width, bottom=0, yerr=mean_stds, label='mean')\n",
+    "ax.bar(ind + width, median_means, width, bottom=0, yerr=median_stds, label='median')\n",
+    "\n",
+    "ax.set_title('Accuracy and AUROC by Imputation Strategy')\n",
+    "ax.set_xticks(ind + width / 2)\n",
+    "ax.set_xticklabels(['Accuracy', 'AUROC'])\n",
+    "\n",
+    "ax.legend(loc='lower right', title='Imputation')\n",
+    "ax.autoscale_view()\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "pleased-purple",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>model</th>\n",
+       "      <th>eval</th>\n",
+       "      <th>impute</th>\n",
+       "      <th>count</th>\n",
+       "      <th>mean</th>\n",
+       "      <th>std</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>dt</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.596277</td>\n",
+       "      <td>0.054962</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>dt</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>median</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.624468</td>\n",
+       "      <td>0.059612</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>dt</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.602911</td>\n",
+       "      <td>0.047092</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>dt</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>median</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.630672</td>\n",
+       "      <td>0.054265</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>lr</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.654255</td>\n",
+       "      <td>0.046910</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>lr</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>median</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.668617</td>\n",
+       "      <td>0.038279</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>lr</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.681374</td>\n",
+       "      <td>0.030784</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>7</th>\n",
+       "      <td>lr</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>median</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.691889</td>\n",
+       "      <td>0.032176</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.680851</td>\n",
+       "      <td>0.064467</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>9</th>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>median</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.689362</td>\n",
+       "      <td>0.051705</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>10</th>\n",
+       "      <td>rf</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.777468</td>\n",
+       "      <td>0.038073</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>11</th>\n",
+       "      <td>rf</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>median</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.792809</td>\n",
+       "      <td>0.041106</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   model   eval  impute  count      mean       std\n",
+       "0     dt    acc    mean     10  0.596277  0.054962\n",
+       "1     dt    acc  median     10  0.624468  0.059612\n",
+       "2     dt  auroc    mean     10  0.602911  0.047092\n",
+       "3     dt  auroc  median     10  0.630672  0.054265\n",
+       "4     lr    acc    mean     10  0.654255  0.046910\n",
+       "5     lr    acc  median     10  0.668617  0.038279\n",
+       "6     lr  auroc    mean     10  0.681374  0.030784\n",
+       "7     lr  auroc  median     10  0.691889  0.032176\n",
+       "8     rf    acc    mean     10  0.680851  0.064467\n",
+       "9     rf    acc  median     10  0.689362  0.051705\n",
+       "10    rf  auroc    mean     10  0.777468  0.038073\n",
+       "11    rf  auroc  median     10  0.792809  0.041106"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "df_impute_model = perturbation_stats(df_metrics, 'model', 'eval', 'impute')\n",
+    "df_impute_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "shaped-korea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt_mean_means = df_impute_model[(df_impute_model['impute'] == 'mean') & (df_impute_model['model'] == 'dt')]['mean'].to_numpy()\n",
+    "dt_mean_stds = df_impute_model[(df_impute_model['impute'] == 'mean') & (df_impute_model['model'] == 'dt')]['std'].to_numpy()\n",
+    "dt_median_means = df_impute_model[(df_impute_model['impute'] == 'median') & (df_impute_model['model'] == 'dt')]['mean'].to_numpy()\n",
+    "dt_median_stds = df_impute_model[(df_impute_model['impute'] == 'median') & (df_impute_model['model'] == 'dt')]['std'].to_numpy()\n",
+    "\n",
+    "rf_mean_means = df_impute_model[(df_impute_model['impute'] == 'mean') & (df_impute_model['model'] == 'rf')]['mean'].to_numpy()\n",
+    "rf_mean_stds = df_impute_model[(df_impute_model['impute'] == 'mean') & (df_impute_model['model'] == 'rf')]['std'].to_numpy()\n",
+    "rf_median_means = df_impute_model[(df_impute_model['impute'] == 'median') & (df_impute_model['model'] == 'rf')]['mean'].to_numpy()\n",
+    "rf_median_stds = df_impute_model[(df_impute_model['impute'] == 'median') & (df_impute_model['model'] == 'rf')]['std'].to_numpy()\n",
+    "\n",
+    "lr_mean_means = df_impute_model[(df_impute_model['impute'] == 'mean') & (df_impute_model['model'] == 'lr')]['mean'].to_numpy()\n",
+    "lr_mean_stds = df_impute_model[(df_impute_model['impute'] == 'mean') & (df_impute_model['model'] == 'lr')]['std'].to_numpy()\n",
+    "lr_median_means = df_impute_model[(df_impute_model['impute'] == 'median') & (df_impute_model['model'] == 'lr')]['mean'].to_numpy()\n",
+    "lr_median_stds = df_impute_model[(df_impute_model['impute'] == 'median') & (df_impute_model['model'] == 'lr')]['std'].to_numpy()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "qualified-wallet",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAlkAAADYCAYAAADYi/YTAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAAA0xklEQVR4nO3debxVVf3/8dcbBEE0HEBNZhUVRzREHNJbjpWGlZlDfnNKrZ9Dc5bDFzPTHEoTlUyJr4qRpaYmjhVZ5gBOCIqKiHDDAXAEQQU/vz/Wurg5nHvvuXAP93J5Px+P/bh7WGvvtffZ++7PXmudfRQRmJmZmVnzatfSBTAzMzNrixxkmZmZmVWBgywzMzOzKnCQZWZmZlYFDrLMzMzMqsBBlpmZmVkVOMgyW4VJmiRpWEuXoyVIGidpeEuXY1XiY2a2cjnIsqqRtKOkxZIebOmyrO4kdZQ0W9K7krqWWT5d0g/KzB8maVJhepSkyMMiSTMkXSVpvTJ5d5F0u6Q3JL0vaYqk/5XUqUzagZL+KOlVSQslTc3b2q459r8p8r4dsrK3W07p8W9CvqMlzSuz6MvAT1a8ZI1ufwdJtxU+zxmSbpbUJy/vm4/zoGbaXk1eX7fmWJ9Zc3GQZdX0TeBKYFtJA1q6MJI6tHQZWtDBwEvAw8ARK7iu+4FPAn2B44GDSJ/zEpK+CPwLmAvsA2wBnAOcANwrqWMh7YHAI8DawFHAAOAw4BXgghUsqxVExBsR8W41tyGpO/A3YB7wBWAr0uf6IvCJJq6rY+OpzFqxiPDgodkHoDPwFrA9cC1wcZk0Q4C/A/OBt0n/mDfJywR8H3gBeB+oBc7Py/oCAQwqWV8Ah5SkOTxvYwFwMrAB8Ie8vgXAZOCYkvU0tO2/A8NL0n8CeA/4cj3HopJtjiMFKr8A5gCvAxcD7QppNgRuy+t4GTgWmAQMq+DzuAc4hXSzm1Bm+XTgB2XmDwMmFaZHAX8tSXMJMLcwvRYwG/hLmfXtBHwE/LAk7e31lHvdBvZpHDACuAx4Mw8X1R0z4Oxi2Qv5HgR+08B6l5xHhelv5WP/HvA88BmgZz6u84EngZ0KeY4mBRkH5fQLgX8Am9Z3bIv5CuNRMhydl30PmJi3/V/gmrpjBdSUyTescMyGF7a3HvB/+dgtIAXQ25TZj73zuTY/70e/Bo7fwcBioGMjx7g4jCueX8CPSdfL63n+14HxwLuka+NPQI+Sa704jCpcyz8iBXgLgKeBr5eUZRfg8fwZPQF8Pq+jJuefSsm1AfTPaXaqbx89eIgIB1keqjOQbuZP5fGa/I+xQ2H5Dvmf3tXAQFLtxYlA77z8fFKQdiywObAr8O28rO6faiVB1nTgEKAf6abYA/hh3uampJqVD4C9C+tpaNuHA28AaxbSn1i6fyXlqmSb40iB5s9ItT6HAouAwwtpxpICtN2BHXOeeTQSZAF9SMFid6BLzjOwJM300htJnj+MBoKsvD+TgVcL876Uj/1u9ZTnPuCJStI2sl/jSDfdy0m1JYfmY/i9vLxnPoaDC3m2zNvboYH1lguy/ps/+/7AjcCrpABraP68xgITC3mOBj4EJhQ+rweApwCVO7aFfHVBVmdSoD0F2DgPnfOy7wCfJZ3ne5ECruvzso7AaaSAqC7f2oVjVgyybsvr3xPYDrgdmFnYTt1+3A8MJj00PQHc08DxG5KP2RF1+1omzc45zf65fOsXzq93gdHAtsB2ef6xpOBn01yOfwAP5GXtSc2gAWyd19c1LzsPeA44gPQ/4Ih8XL6Ql69NCvJvBLYB9iWdzwHU5DQ/AZ4pKf/55HPYg4eGhhYvgIe2OQD/JN+0SU+D04GvFJaPBh6uJ+/apKfKk+pZ3pfKg6zvV1DWMcA1FW57TVJN02GFeY9Qpqau0m3m6XHAQyVp7iuUa4u8P7sXlvch1RgMa2Rb57B0YHQdcHlJmulUHmQtIgVqC/i45uC7hTQ/zvPWq6c8lwHv5fEfNZS2kf0aR6olUmHemUBtYfqvwIjC9C8pU5NX33lUmD6/ML1tnve9wryaPK9bnj66gc9rn3LHtpBvXn3Hv4EyH0AKpNuVW0/JMRuex+tqY/YsLO9KClSPL9mPLQtpjiQ9JLRroDznkYKzN4F7gZ8CfQrL+1L+Gh5FCnrWbGR/t8r5e5Y7/nlel3yOfrok76XA2Dx+IumhqXNh+REsHWRtnPdlSJ5uTwq6T27qOeth9RvcJ8uanaTNSU/vNwJERJCCquMLyXYkNQ+WszUpmKlveVNMKClbe0lnSJooaW7uHPxloHcl246I94HrSU/WSNqa9GQ9sr4CVLDNOhNLpmeRmggh1fR9BDxaKMvLOU29JLUj3SivL8y+HjiyXAf0Cj1AqpUbTKpFGgv8pgn5RbqJ1Y2viIfz+VXnIaCHpLq+P78DDpPUWVJ7Ug3rtcuxneJn81r++3SZeRsW5tX3eW29HNtfiqTPSrpPUq2kd4FbSDVYGzdhNXXn1EOFMr5N2q9iGd+PiOcK07OADsC69a04Is7IZTkhr+844BlJe1dQrkn5OltC0k65I/3LeX/rruvSa6hoa6ATcLekeXUDqel3s5xmq7y9BYV8j5Tsy6ukYP3YPOsAUheA0RXsi63mHGRZNRxPetqbkb+Btgg4HdhPUq+cpqGba2M33o9K0zXQqX1+yfQPSP2tLiL1MxkI/IV0g6pk25D6v+wtqTfp5vFQRDzTQPrGtlnnw5Lp4ONrdHmDkf1IN6LRhc/iLlJfnK8U0r1DqsUotS6pZqPovYiYGhFPR8SppH5VZxWWP5//1hdMDCD1dyumrdYXI+4k9aP6Cqm5aV1S/7imKn420cC8pvxP/YhlP9dGv5yRv6F3J/As8FXgU3wcADSlo3hD51QxcF1Uz7IG9zUi5kbEnyLi+6TPdzpLnyf1WeqaldSF1DT7HilI3pkU6EDD+1tXvoNI11zdsA3puoClA/6GXAN8TdJapGN9S0S8WUE+W805yLJmJWkN4BukfgwDC8MOpNqAY3LSx0l9Ssp5htT0Ud9T7+z895OFeQMrLOIewB0RcX1EPEnqELtFE7ZNREwmPe1+k9Qht95arAq3WYlnSdfrznUzcpC3SSP5jiPVcgwsGX6Xl9V5jnSzLrVTXtaQc4AfS6ory72kbxX+sDShpJ1Ix3Z0Ie0cUhC+DEnrNrLtXSQVg4UhwKyIeAcgIhaRmqCO5eOb41uNrLO51Pd5PZtnzQY2Kin/wJJ1fEB6YCkaRAouvhsRD0XE8yx7HpTLV+qZXMZdC2X8BKlvVkMPDU0WER+Qzvu1C+WjgjJCqm3qBvw0Ih6IiCksXWNY3/rqruU++aGgOLyc0zwLbCepcyHf4DJluJv0IHISKWhr7Jo3S1q6vdJD2xpIHYE/BDYos+zHpKfZdqSbyUJSx/cdSB2Sj+fjju+/JPXnOIZUtT8Y+FZhXQ+RviW2DbAbqQ9YuT5ZpX0+LiF9a2kP0j/vK0g1NeMKaRrcdk5zDOkf+DxgnUaOSSXbHMey31ocxdJ9qe4iNb3smo/f32mg4zvpxvQ+8MUyy3Yh1aRslqd3I/UXOotUA7UNH/er2b6+MhXmTwCuLEx/KecdSWoa7k16LUMtqbmxYyHtUNJN8k5Sx+O+pODuXODOBo7rOFIn6cvy+XMI6QsLpd8E2zTv24fAZyo4h8v1ySpOd6PQZyfPq+sjtG2ePjpv79HC5/UP0oNGXcf3uua6M/J5dhyp2bHYJ+sIUg3OTnm7a5I6nwepdrQfqUP+jDyvb+HzjHw8uwFrlTvPSDWqzwKfpv6O7/NKjk8NJf2fSpYfCNyQ/26RP5sfkGrEzshp1sj7dTawER93VB/Fst9e7U76X3FJ/iy/wLKd03vkY3lsTl/X0f/npIC/7kssA0mB0gl5eV3H9xtI5/0+pGssgL1KynEO6Xp6iXo69HvwUDq0eAE8tK0h/5O+t55lm+Z/Xvvl6T1IN9wFpJvj/cAn87J2pNqNaaQb8EzgvMK6BpCCrPfyP8VPU1mQtR6pZqfuq+AXkl6dMK6QpsFt5zRr5XWMrOCYVLLNcTQeZG2Uj++CXKbjaeAVDqSv+b9DPZ2ISa+B+EVhej/Su63eyDemcRQ6RZcrU2H+EXxca1A3b1dSX5Y387LnSB25O5XJ/ynS1/Jfy2lfzNvaplzZC8dsBDA8nz9vkm7E7cuk/XteZ6M3R5ovyJpHCiDrXgXyT2Dzkm2dmD+H+aQvQ5zG0kHWmsCf874FH7/C4VRS5+sFpP6Dh1IIsnKaq0i1hMEKvsKhpMw1NBxkbZo/lyl8/HqWJ0nfiCx+SeF4UnC4mJJXOJRZ59fy57eQFLjuX+YzOIv0brWPWPoVDqfwca3WbNIXSvYt5BtC+sbk+/nvV/K6dykpQ588/+zGziEPHuqGuicqM2uC3DQ2g/S06zfat3KSngFGR8R5K2l7R5OCmbUbS2uti6ShwK3AhhExpzB/F9KD3aYRMaOlymerljVaugBmq5Lcwf6TpKa0JxxgtW6SNiQ1p/UFftuypbHWSNI3SLXWM0mv57iU1IdyTl6+JtCL1PR4qwMsawoHWWZNszupb80LpCYaa91eIzWZnVislTAr2IjU3+qTpJfM3knqP1rncNJrP57i429xmlXEzYVmZmZmVeBXOJiZmZlVgYMsMzMzsypwkGVmZmZWBQ6yzMzMzKrAQZaZmZlZFTjIMjMzM6sCB1lmZmZmVeAgy8zMzKwKHGQ1I0kjJJ21HPl6S5onqX01ytVaSbor/6SFWUUqPWfy9bTpyiiTWUuQNEzSDS1dDmvYahtkSZouaZ/mXGdEnBQR5zZ12xExIyLWjojFTdmepKMlLc43lHckPSXpwOUpe0uIiM9FxP+1dDmseeXze4GkdyW9Jek/kk6StML/byo9Z/L1NG1Ft1eUr7O64aO8j3XTRzbntmzVVDj350l6VdIoSav0j4RLqsnne/H8v2Mlbr+vpJC0Sv4M4GobZLUhD0XE2sC6wJXAGEnrNvdGVrdaNlthB0XEOkAf4ALSb8Fd27JFWjE5cFs7X28zSPtYN290XbpV9WZgzeagfI4MBHYEftKyxWkWs4rnf0Qc1NQVrK73EAdZJSStKelSSbPycGn+Ffa65T+S9EpednyOsDfPy0ZJ+nke7ybpr/lJ/g1J/5LUTtL1QG/gjvxE8KPSSF3S+pJ+n7fxpqS/NFbuiPgIuB7oAvQv7MvFkmZIei03Z3Zuwr5cJWmspPnAZyRtIulmSbMlvSTp1MK6BkuakGvUXpP0qzy/k6QbJM3Nx2K8pI3ysnGSjs/j7SSdKellSa9Luk5S17ys7vh8I+/LHElnLPeHbCtNRLwdEbcDXwO+IWlbqOjcHCrpyXw+vSjpgDy/eM5sLumfkt7O58QfC/mL53LXfD7NzufXmcq1akq1wf/OZXkzn9efa8o+Kj3p10r6saRXgd/n8/n0XPa5km6StH4hzxClGr63lGqga5bzEFsrFRGvAveQgi0ACufEu5KekfSlwrIGz0VJ/fL5/q6k+4Buxe1J+qKkyfmcGidpQGHZdEk/lDRR0nxJ10raSKn5/V1J90tar6n7KGlA3tZbedtfLCxrlnsI8ED++5bSPXPXppazJTnIWtYZwBDShbEDMBg4EyD/o/8esA+wObBXA+v5PlALdCf9yvtPgYiIo1j6KfjCMnmvB9YCtgE2BH7dWKGVnhKOAT4EXs6zfwlskfdlc6AHcHYT9uUI4DxgHeA/wB2kX6LvAewNfEfS/jntZcBlEfEJYDPgpjz/G0BXoBewAXASsKDMto7Ow2eATYG1geElafYAtszbPrv4T8Rat4h4lHQ9fDrPaujcHAxcB/yQVEO7JzC9zGrPBe4F1gN6ApfXs/nLSefgpqTz/H9I10qdXYDnSDetC4FrJamJu7gxsD6p5u4E4FTg4Ly9TYA3gSvy/vUA7gR+nvP8ALhZUvcmbtNaMUk9gc8BUwuzXyRdA12Bc4AbJH2ysLyhc/FG4LG87FzS/9a6bW0B/AH4DumeM5b0IN+xsO6vAPuSrruDgLtI96VupFjgVJpAUgfSPeFe0n3qFGC0pC0LyZrjHrJn/rtuvmc+1JRytriIWC0H0j/tfcrMfxH4fGF6f2B6Hh8JnF9YtjkQwOZ5ehTw8zz+M+C2umUNbRvom9ezBvBJ4CNgvQr24WhgEfAWKbhaAByalwmYD2xWSL8r8FIT9uW6wvJdgBkl2/8J8Ps8/gDpn0a3kjTHki6u7cuUfxxwfB7/G/DtwrIt8z6tUTg+PQvLHwUOa+nzyEOTrq2HSQ8xjZ2bvwV+Xc+6i+fMdcDVxfOikC7yOd0eeB/YurDsRGBcHj8amFpYtlbOu3Gl+wjUAB8AnQrLnwX2Lkx/snA+/xi4vmR99wDfaOnPzsOKDfm8mAe8m8+jv5GCg/rSPwkMzeP1nouk1o9FQJfC8huBG/L4WcBNhWXtgP8CNYVyHVlYfjNwVWH6FOAv9ZSxhnRPeqswHEoKFl8F2hXS/gEYlsdH0Tz3kL75OKzR0p/v8gyuyVrWJnxcE0Qe36SwbGZhWXG81EWkJ5h7JU2TdHqF2+8FvBERb1aY/uGIWJf0NH87H9cUdCddpI/lqty3gLvzfKhsX4rz+gCb1K0rr++npFo6gONIT0hTlJoE6zrgX0+6gYxRapa8MD8BlSp33NcorB/SBV3nPVJtl606egBv0Pi52Yv0sNOYH5ECtkdzU8WxZdJ0Azqy7LnVozC95LyKiPfyaFPPrdkRsbAw3Qe4tbB/zwKLSedzH+CrJdfSHqRAzFZ9B0fqj1gDbEWhWU/S/yg1g9d97tuydLNffefiJsCbETG/kLZ4Ti/1/zNS95GZLH2ev1YYX1BmuqFzflZErFsYbsrbnJm3VSxTcZvNcQ9ZpbmD5rJmkU6GyXm6d54H8AqpWaJOr/pWEhHvkpoMvy9pG+AfksZHxN9IUXl9ZgLrS1o3It6qtNARMU/St4EXJY0kVckuALaJiP+WyVLJvhTLOZNU09C/nu2/AByu1Nfly8CfJW2Q/ymcA5wjqS+pGvs5lu0EXXfc69Q9ub1WUk5bBUnamfTP99/AHBo+N2eSmgsaFKnPyzfz+vcA7pf0QEQUm2fmkGqQ+gDP5Hm9SU/5zan0mp4JHBsRD5YmlDSTVJP1zWYug7UiEfFPSaOAi4GDJfUBfkdqJnsoIhZLepL0oNCYV4D1JHUpBFq9+fi8mwVsV5c4NzH2ovnP86JZQC9J7QqBVm/g+UKaFb6H0PD9stVb3WuyOih1zK4b1iBVd54pqbukbqR+InXvIrkJOCZ39lsrLytL0oFKHXMFvEN6iq17RcNrpP4hy4iIV0ht5VdKWk9SB0l7lktbJu9c4Brg7HzS/w74taQNc5l6FNq/K96X7FHgHaXOvZ0ltZe0bb55Iunrkrrn7b6V8yyW9BlJ2+U+Y++QbnjlXlXxB+C7Sp071wZ+AfwxIhZVsu/WOkn6RH4iHUNq2ni6gnPzWtK5ubdSB/IekrYqs+6v5n4vkPo8BSXnVqTXotwEnCdpnXyj+x4fX9PVMiJvs08ua3dJQ/OyG4CDJO2fr6NOSp3n/TDR9lwK7CtpIOlLSQHMBpB0DKkmq1ER8TIwgfSw2jE/VBS/4XcT8IV8zXQgPeC/T+qqUS2PkJr9f5TvUzW5TGPqSb9c9xDS8fqIeu6Zrd3qHmSNJT1R1w3DSJ1RJwATgaeBx/M8IuIu4DfAP0hNgXUd8N4vs+7+wP2k9vmHgCsjYlxedj4pkHtL0g/K5D2KFIxMAV4ndWas1KXA5yVtT+r7MRV4WNI7uTxbLse+1N2sDiJ1VH6JVENwDakDJ8ABwGRJ80gdGA/LzScbA38mBVjPAv+k/A1uJKlp8YG8/oWkfgK2arpD0rukp9czgF+xdGfzhs7NR3PaXwNvk86ZYi1nnZ2BR/I5dztwWkS8VCbdKaSbwTRSTdqNpPOtmi7LZbo3H4eHSX1SiIiZwFBSU8ls0jH6If5/3OZExGxS38GzIuIZ4BLS/9rXSDVPy9R0NuAI0jn0BvC/eb1123kO+DrpSx5zSP+rD4qID5phN8rK6/4iqXP/HNIrhP4nIqbUk3657iG52fQ84MF8zxxSrX2qBuWOZbYclL7dNglYc1WvcWlL+2JmZtYa+MmpiSR9KVfXrkf6Gvodq2pQ0pb2xczMrLWpKMiSdICk5yRNVZlvySm97O8OpZfqTc5tzXXLpkt6WukbFROas/At5ERSFf+LpPbib7VscVZIW9oXMzOzVqXR5sLcYfl50kvMaoHxwOG5fbkuzU+BrhHxY6UX6j1Hes/MB5KmA4MiYk6V9sHMzMys1amkJmsw6QVp03JHtzGkTptFAayTv0m3NqljnpudzMzMbLVVSZDVg6VfKFbL0i8bg/TzJwNI7814mvQtn7r3ZgTpGzaPSTphBctrZmZmtkqo5GWk5V6UVtrGuD/p5wE+S3qJ4H2S/hUR7wC7R8Ss/D6c+yRNiYgHSvKTA7ATALp06fKprbZa5rU4Zi3isccemxMRLfq7ct26dYu+ffu2ZBHMlmjpa8LXg7U29V0TlQRZtSz9NvCefPwG9DrHABdE6uA1VdJLpJ8TeDQiZgFExOuSbiU1Py4TZEXE1aTfIWPQoEExYUJb6CNvbYGklxtPVV19+/bF14S1Fi19Tfh6sNamvmuikubC8UD//CbujsBhpJfsFc0g/VQAkjYivVRwmqQuktbJ87sA+5HexWRmZmbWpjVakxURiySdTPqR3/bAyIiYLOmkvHwEcC4wStLTpObFH0fEHEmbkn4ktW5bN0bE3VXaFzMzM7NWo6IfiI6IsaSfoCnOG1EYn0WqpSrNNw3YYQXLaGZmZrbK8RvfzczMzKrAQZaZmZlZFTjIMjMzszatpqaGmpqalb5dB1lmZmZmVeAgy8zMzKwKHGSZmZmZVYGDLDMzM7MqcJBlZmZmVgUOsszMzMyqwEGWmZmZVV1LvUahJTnIMjMzM6sCB1lmZmZmVVBRkCXpAEnPSZoq6fQyy7tKukPSU5ImSzqm0rxmZmZmbVGjQZak9sAVwOeArYHDJW1dkuz/Ac9ExA5ADXCJpI4V5jUzMzNrcyqpyRoMTI2IaRHxATAGGFqSJoB1JAlYG3gDWFRhXjMzM7M2p5IgqwcwszBdm+cVDQcGALOAp4HTIuKjCvOamZmZtTmVBFkqMy9KpvcHngQ2AQYCwyV9osK8aSPSCZImSJowe/bsCoplZmZm1npVEmTVAr0K0z1JNVZFxwC3RDIVeAnYqsK8AETE1RExKCIGde/evdLym5mZmbVKlQRZ44H+kvpJ6ggcBtxekmYGsDeApI2ALYFpFeY1MzMza3PWaCxBRCySdDJwD9AeGBkRkyWdlJePAM4FRkl6mtRE+OOImANQLm91dsXMzMzarGFdlz/v9Pkrto5hby9XtkaDLICIGAuMLZk3ojA+C9iv0rxmZmZmbZ3f+G5mZmZWBQ6yzMzMzKrAQZaZmZlZFTjIMjMzM6uCijq+m5mZmQH0Pf3O5cr36rS5K5R/eqflytaiXJNlZmZmVgUOsszMzMyqwEGWmZmZWRU4yDIzMzOrAgdZZmZmZlXgIMvMzMysChxkmZmZmVVBRUGWpAMkPSdpqqTTyyz/oaQn8zBJ0mJJ6+dl0yU9nZdNaO4dMDMzM2uNGn0ZqaT2wBXAvkAtMF7S7RHxTF2aiLgIuCinPwj4bkS8UVjNZyJiTrOW3MzMzKwVq6QmazAwNSKmRcQHwBhgaAPpDwf+0ByFMzMzM1tVVfKzOj2AmYXpWmCXcgklrQUcAJxcmB3AvZIC+G1EXL2cZTUzMzNrsnFHd2mR7VYSZKnMvKgn7UHAgyVNhbtHxCxJGwL3SZoSEQ8ssxHpBOAEgN69e1dQLDMzM7PWq5LmwlqgV2G6JzCrnrSHUdJUGBGz8t/XgVtJzY/LiIirI2JQRAzq3r17BcUyMzMza70qCbLGA/0l9ZPUkRRI3V6aSFJXYC/gtsK8LpLWqRsH9gMmNUfBzczMmlNNTQ01NTUtXQxrQxptLoyIRZJOBu4B2gMjI2KypJPy8hE56ZeAeyNifiH7RsCtkuq2dWNE3N2cO2BmZraqqwvuxo0b16LlsOZVSZ8sImIsMLZk3oiS6VHAqJJ504AdVqiEZmZmtsrb+IgLWroIK53f+G5mZmZWBQ6yzMzMzKrAQZaZmZlZFTjIMjMzM6sCB1lmZmZmVeAgy1Z5freNmZm1Rg6yzMzMzKrAQZaZmZlZFTjIMjMzM6sCB1lmZmZmVeAgy5qFO5+bmZktzUGWmZmZWRVUFGRJOkDSc5KmSjq9zPIfSnoyD5MkLZa0fiV5zczMzNqiRoMsSe2BK4DPAVsDh0vaupgmIi6KiIERMRD4CfDPiHijkryrAzelmZmZrX4qqckaDEyNiGkR8QEwBhjaQPrDgT8sZ14zMzOzNqGSIKsHMLMwXZvnLUPSWsABwM3LkfcESRMkTZg9e3YFxWoa1yaZmZnZylRJkKUy86KetAcBD0bEG03NGxFXR8SgiBjUvXv3CoplZmZm1npVEmTVAr0K0z2BWfWkPYyPmwqbmtfMzMyszagkyBoP9JfUT1JHUiB1e2kiSV2BvYDbmprXzMzMrK1Zo7EEEbFI0snAPUB7YGRETJZ0Ul4+Iif9EnBvRMxvLG9z74S1EcO6Ll++6fNXLP+wt5cvn5mZWQMaDbIAImIsMLZk3oiS6VHAqErympmZtUl+WLQCv/HdzMzMrAocZJnZSudXqlSXj69Z61BRc6GtPvqefudy5Xt12twVyg8wvdNyZzUzW8L/x6y1cE2WmZmZWRU4yDIzMzOrAgdZZmZmZlXgIMvMzMysChxkmZmZmVWBv13YFH7JnJmZmVXINVlmZmZmVeAgy8zMzKwKKmoulHQAcBnpR56viYgLyqSpAS4FOgBzImKvPH868C6wGFgUEYOaodxmS4w7uktLF8HMzGwZjQZZktoDVwD7ArXAeEm3R8QzhTTrAlcCB0TEDEkblqzmMxExp/mKbWZmZta6VdJcOBiYGhHTIuIDYAwwtCTNEcAtETEDICJeb95impmZma1aKmku7AHMLEzXAruUpNkC6CBpHLAOcFlEXJeXBXCvpAB+GxFXr0iB/ZtUZmZmtiqoJMhSmXlRZj2fAvYGOgMPSXo4Ip4Hdo+IWbkJ8T5JUyLigWU2Ip0AnADQu3fvpuyDtQIbH7FMNz1r5WpqagAYN25ci5ajrfLxNbNKmgtrgV6F6Z7ArDJp7o6I+bnv1QPADgARMSv/fR24ldT8uIyIuDoiBkXEoO7duzdtL8zMzMxamUqCrPFAf0n9JHUEDgNuL0lzG/BpSWtIWovUnPispC6S1gGQ1AXYD5jUfMU3MzMza50abS6MiEWSTgbuIb3CYWRETJZ0Ul4+IiKelXQ3MBH4iPSah0mSNgVulVS3rRsj4u5q7YyZmZlZa1HRe7IiYiwwtmTeiJLpi4CLSuZNIzcbmpmZma1O/NuFZmZmLcwvVW6b/LM6ZmZmZlXgIMvMzMysCtxcaGbWGg3ruvx5p89fsXUMe3v5t21mSzjIWgnc1m5mZrb6cZBlZmZmfPjhh9TW1rJw4cIG0/3ui59cSSVa2rO6qUW2mzb+LACdOnWiZ8+edOjQoaJsDrLMbPktb3OUm7PMWp3a2lrWWWcd+vbtS36/ZVkf1r618gpVMKBd/WWquk0GEBHMnTuX2tpa+vXrV1E2d3w3MzMzFi5cyAYbbNBggLU6k8QGG2zQaE1fkYMsMzMzA3CA1YimHh8HWWZmZsDGR1zAxkdc0NLFWCUM2bJn1bdxzeWXVJTuF7+5dqnp3b54dBVKs3wcZJmZmVmrc83wX1eU7heXj1xq+j+3j6pCaZaPO76bmZnZchn/0L+56pLz2aD7hkyZ/DR7f+5A+m+1NaOv/S3vL1zApdeMplfffpz13W/TsdOavPjcFObOmc0Pzv45e+1zALfddCOTJz7BT3+efvr45KO/xjdOPIUHx93P+wsXcOj+n2azLbbi/Mt/x8HHfo+Zs15l4fsfcNpxh3PC17/C6b/4DQsWvs/AfQ9jmy03Y/Tw81i7/+7Me+FBIoIf/fxS7vrHf5DEmacex9eG7s+4/0xg2K9+S7f11mXScy/yqe0HcMPlP69KU2lFQZakA4DLgPbANRGxTH2qpBrgUqADMCci9qo0r5mZma2ann92Erde8Qhd112Pz+++I18+/Chu/OvfGH3tCP4w6mp+NOx8AGbNnMnIP9/JzJdf4vhDv8iQPWrqXed3fjKMMaOu4aZ7/rVk3shL/pf11+vKggUL2fkLR/GVz+/NBT89leG//yNP3jdmmXXcMvbvPDn5eZ66bwxz3niLnT9/FHsO2QmAJyY9x+S//4lNNu7O7kOP4cHxT7LH4B2b98BQQZAlqT1wBbAvUAuMl3R7RDxTSLMucCVwQETMkLRhpXlXFrezm5mZNb9tdtiJ7httDECvPn3Zdc/PALD5Vlsz/j8fB0n7HXgw7dq1o0+/zejZuw8vvfhCk7bzm5F/4Na7/gHAzFmv8cJLM9hg/XXrTf/vR5/g8IP3p3379mzUfQP2GrIT4596hk+s3YXBA7eh5yYbATBwmy2ZPnNWVYKsSvpkDQamRsS0iPgAGAMMLUlzBHBLRMwAiIjXm5DXzMzMVlEdOnZcMt6uXTs6dlxzyfiixYuWLCttjpOg/RrtiY8+WjLvg/ffL7uN8Q/9m/v/9SgP3TGKp+7/IztuuyUL3/+gwXJFRL3L1uz48ctE27dvx6JFixtc1/KqpLmwBzCzMF0L7FKSZgugg6RxwDrAZRFxXYV5zcxarb6n37lc+V6dNneF8k/vtFzZzFqt++78C1/86uH8d8bL1M54mb6b9mf+vHncdN21fPTRR7z+6iwmPfn4kvRrdFiDDz/8kA4dOjDvnXdYr+s6rNW5M1OmvsTDjz+9JF2HQrqiPYfsxG9vuJlvfPUg3njrHR545HEuOus7TJk6fWXtckVBVrmeYKXh4RrAp4C9gc7AQ5IerjBv2oh0AnACQO/evSsolpmZma0q+m7an2MP+QJz58zmzPMvYc1Ondhx5yH06NWHr+y7O5tvMYAB226/JP1XjvgGX91vDwZsuz3nXDycu0dfwfb7HMqWm/ZlyE7bLUl3wpFfZvt9vsZO2w1g9PDzlsz/0uc+y0OPTWSHfQ9DEheecRobb9it1QVZtUCvwnRPYFaZNHMiYj4wX9IDwA4V5gUgIq4GrgYYNGhQ/XV8ZmZm1qIefq4WgJ133YOdd91jyfxr//TXJeOlywbuvAs/HPaLpdYjifMv/13ZbXz3p+fw3Z+es2T6rhuGl033yzNO45dnnLZket4LDy5Z90VnfZeLzvruUulrdhtEzW6DlkwPP+/08jvZDCoJssYD/SX1A/4LHEbqg1V0GzBc0hpAR1KT4K+BKRXkNbMV0FLNWeAmLTOzhjQaZEXEIkknA/eQXsMwMiImSzopLx8REc9KuhuYCHxEelXDJIByeau0L2ZmZtYKnfvrK1u6CC2iovdkRcRYYGzJvBEl0xcBF1WS18zMzKyt88/qmJmZmVWBgywzMzOzKnCQZWZmZlYFDrLMzMzMqqCiju9mZma2elmR17uUc/vJuzfr+lYFDrLMzNqYcUd3aekimC2X/86cwbePOoQddx7CxMfHs+XW2zL00CO56lfnM2/OK4wefh7bbLkZp5z5S56eMpVFixYz7PsnMnT/GqbPnMVRp57J/PcWAjD85z9mt513YNx/JjDsV7+l23rrMum5F/nU9gO44fKfL/NbitXgIMvMzMxajZnTp3HxVb/n7F9eyhEHfpaxf/kzo265m+n3j+IXl49k6/79+OzuOzPyV8N46+13GfyFo9jn07uwYbf1uO8PV9Gp05q8MG0Gh/+/nzDhrtEAPDHpOSb//U9ssnF3dh96DA+Of5I9Bu9Y9X1xkGVmZmatRo9efeg/YBsANttiK3bZY08ksd1WmzN95ixqX3mN2+97gItHXA/Awvc/YMZ/X2GTjbpz8hm/5Mlnnqd9u3Y8P23GknUOHrgNPTfZCICB22zJ9JmzHGSZmZnZ6qVDx45LxtupHR07rpnG27Vj0eLFtG/fjpuvvogtN++7VL5hl4xgo+4b8NR9Y/joo4/otOmuS5at2bHDkvH27duxaNHi6u5EXflXylbMzMzMmsH+e+3K5b8fQ0QA8MSkKQC8/c48PrlhN9q1a8f1N9/J4sUrJ5BqiIMsM1vpxh3dxZ2zzWy5nPWdb/Lhh4vYfp+vse1nv8pZF6bfRfz2Nw7l//58B0MO/B+enzaDLmt1buGSurnQzMzMyph+wRfKzp9Y+1bVttmjV29u+dtDS6aLPyzdt9cmTPr7nwD47YVnLpO3/6a9mXj/TUumz//JKQDU7DaImt0GLZk//LzTm73c9amoJkvSAZKekzRV0jKlk1Qj6W1JT+bh7MKy6ZKezvMnNGfhzczMzFqrRmuyJLUHrgD2BWqB8ZJuj4hnSpL+KyIOrGc1n4mIOStWVDMzM7NVRyXNhYOBqRExDUDSGGAoUBpkmZlZtvERF7R0EcyshVXSXNgDmFmYrs3zSu0q6SlJd0napjA/gHslPSbphBUoq5mZmdkqo5KarHLvnY+S6ceBPhExT9Lngb8A/fOy3SNilqQNgfskTYmIB5bZSArATgDo3bt3peU3MzMza5UqqcmqBXoVpnsCs4oJIuKdiJiXx8cCHSR1y9Oz8t/XgVtJzY/LiIirI2JQRAzq3r17k3fEzMzMrDWpJMgaD/SX1E9SR+Aw4PZiAkkbK//SoqTBeb1zJXWRtE6e3wXYD5jUnDtgZmZmVqrmkG8y4anUffzzR53CW2+/u9LL0GhzYUQsknQycA/QHhgZEZMlnZSXjwAOAb4laRGwADgsIkLSRsCtOf5aA7gxIu6u0r6YmZlZcxnWtezs7ZdzdROPf3n5y7KCxl5/eYtst6KXkeYmwLEl80YUxocDw8vkmwbssIJlNLMq8LffzKy1+e/MGXz7qEPYcechTHx8PFtuvS1DDz2Sq351PvPmvMLo4eexzZabccqZv+TpKVNZtGgxw75/IkP3r2HBgoUc871hPPPCNAZs3o8FC99fst6+u3yBCXfdQLf11+PgY7/HzFmvsvD9DzjtuMM54etfAWDt/rtz2nGH89f7/0XnTmty2+9/zUbdN1ih/fHP6piZmVmrMXP6NI489kT+fN+DvPTiC4z9y58ZdcvdXHz2d/nF5SM577Jr+OzuOzN+7A38409X88NzL2X+ewu46ro/s1bnTky8/ybOOPU4Hpv4bNn1j7zkf3ns7huZMPYGfjNyDHPfeAuA+e8tYMhO2/HU/X9kzyE78bvRt67wvvhndczMzKzV6NGrD/0HpDdBbbbFVuyyx55IYrutNmf6zFnUvvIat9/3ABePuB6Ahe9/wIz/vsIDjzzOqcceBsD2W2/B9gP6l13/b0b+gVvv+gcAM2e9xgsvzWCD9delY8cOHLjvngB8arsB3PevR1Z4XxxkmZmZWavRoWPHJePt1I6OHddM4+3asWjxYtq3b8fNV1/Elpv3XSZv7gNer3H/mcD9/3qUh+4YxVqdO1NzyDdZ+P4HabtrrLEkf/v27Vm0aPEK74ubC83MzGyVsf9eu3L578cQkV7Z+cSkKQDsuctOjL71LgAmTZnKxGdfWCbv2+/OY72u67BW585MmfoSDz/+dFXL6iDLzMzMVhlnfeebfPjhIrbf52ts+9mvctaFVwLwrf85hHnz32P7fQ7lwiv/j8EDt1km7wE1u7Fo8WK23+dQzrrwKobstF1Vy+rmQjMzM1vWsLfLzp5Y+1bVNtmjV29u+dtDS6bP/fWVS8b79tqESX//EwC/vfDMZfJ27tyJMVeV/9b09EfuXDJ+1w3LvAwBgHkvPLhk/JAD9+GQA/dpWuHLcE2WmZmZWRU4yDIzMzOrAgdZZmZmZlXgIMvMzMwAlnxjz8pr6vFxkGVmZmZ06tSJuXPnOtCqR0Qwd+5cOnXqVHEef7vQzMzM6NmzJ7W1tcyePbvBdK+9uWAllWhpz6rhclXV2+knejp16kTPnj0rzlZRkCXpAOAyoD1wTURcULK8BrgNeCnPuiUiflZJXjMzM2t5HTp0oF+/fo2m+9zpdzaaphqmdzqiRbYL1Ps6i8Y0GmRJag9cAewL1ALjJd0eEc+UJP1XRBy4nHnNzMzM2pRK+mQNBqZGxLSI+AAYAwytcP0rktfMzMxslVVJkNUDmFmYrs3zSu0q6SlJd0mqe5d9pXnNzMzM2pRK+mSV+0nr0q8ePA70iYh5kj4P/AXoX2HetBHpBOCEPDlP0nMVlG2lEnQD5qz0DZ/T8K+KtxWt+Pj2WRnFaMhjjz02R9LLLV2OUq34M1vltdixhVZ/TbTW6wF8TVTTqnhNVBJk1QK9CtM9gVnFBBHxTmF8rKQrJXWrJG8h39XA1RWUp8VImhARg1q6HG2Vj2/9IqJ7S5ehHH9m1eNjW7/Wej2AP7dqWhWPbSXNheOB/pL6SeoIHAbcXkwgaWNJyuOD83rnVpLXzMzMrC1qtCYrIhZJOhm4h/QahpERMVnSSXn5COAQ4FuSFgELgMMivc2sbN4q7YuZmZlZq1HRe7IiYiwwtmTeiML4cGB4pXlXYa26ObMN8PFd9fgzqx4f21WTP7fqWeWOrfz6fDMzM7Pm598uNDMzM6uCNhtkSfqSpJC0VUuXZXVReswl1Uj6a0maUZIOyePjJD2X3682XtLAQrqukq6T9GIerpPUtbB8C0ljJU2V9KykmyRttJJ2dZXka2Ll8zXRuvmaWPlWt2uizQZZwOHAv0nfaKyK/LNB9rHlOeZHRsQOwJXARYX51wLTImKziNiM9LuY1wBI6gTcCVwVEZtHxADgKqDVfq27lfA1sfL5mmjdfE2sfKvVNdEmgyxJawO7A8eRP0hJ7SVdLOlpSRMlnZLn7yzpPzlKflTSOpKOljS8sL6/Kv0INpLmSfqZpEdIb7k/O0fXkyRdLS15lcXmku7P631c0maSrpc0tLDe0ZK+uLKOSzWVO+ZN9BD51wAkbQ58Cji3sPxnwCBJmwFHAA9FxB11CyPiHxExaTmL3+b5mlj5fE20br4mVr7V8Zpok0EWcDBwd0Q8D7whaSfS2+T7ATtGxPbAaKV3d/0ROC1HyfuQXkHRkC7ApIjYJSL+DQyPiJ0jYlugM1D3I9mjgSvyencDXiFF2MdAqubM89vKNy8PZtlj3hQHkH4pAGBr4MmIWFy3MI8/CWwDbAs8toLlXd0cjK+Jle1gfE20Zgfja2JlO5jV7Jqo6BUOq6DDgUvz+Jg8vSkwIiIWAUTEG5K2A16JiPF53jsA+SGjPouBmwvTn5H0I2AtYH1gsqRxQI+IuDWvd2FO+09JV0jaEPgycHNdedqAcsf8r/WkLX6ldbSkLqT3qNVdcKL8zy/VN98a52ti5fM10br5mlj5Vrtros0FWZI2AD4LbCspSB9KkCLa0gNf34exiKVr+ToVxhfWRc5Kbb5XAoMiYqakYTltQ1ff9cCRpKrSYyvcrVatgWN+HbBeSfL1Wfq3p44EngIuAK4g/VOZDOwoqV1EfJS30Q7YAXgW2BDYq2o71Mb4mlj5fE20br4mVr7V9Zpoi82FhwDXRUSfiOgbEb1IneEeB06StAaApPWBKcAmknbO89bJy6cDAyW1k9QLGFzPtuouqjm5rfkQWPKkUyvp4LzeNSWtldOOAr6T07WVt9/Xd8zXJx3fAQCS+pAugCeLmSPiQ+BMYIikARExFXgiz6tzJvB4XnYjsJukL9QtlHRAfuK0ZfmaWPl8TbRuviZWvtXymmiLQdbhwK0l824GNgFmABMlPQUcEREfAF8DLs/z7iNdEA+SPvyngYtJF94yIuIt4Hc53V9Iv9VY5yjgVEkTgf8AG+c8r5Gi7N+v4H62JvUd88OArwO/l/Qk8Gfg+Ih4u3QFEbEAuAT4QZ51HLCF0ldvXwS2yPPq0h4InCLpBUnPAEcDrzfzfrUVviZWPl8TrZuviZVvtbwm/Mb3lSw/qTwN7FTuJDJb3fiaMFuar4m2oy3WZLVakvYhVT1f7gvHzNeEWSlfE22La7LMzMzMqsA1WWZmZmZV4CDLzMzMrAocZJmZmZlVgYMsMzMzsypwkGVmZmZWBQ6yzMzMzKrg/wNNRqFS7K8qogAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 720x216 with 3 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "fig, axs = plt.subplots(1, 3)\n",
+    "\n",
+    "fig.subplots_adjust(top=0.8)\n",
+    "\n",
+    "fig.set_figheight(3)\n",
+    "fig.set_figwidth(10)\n",
+    "\n",
+    "fig.suptitle('Accuracy and AUROC by Imputation Strategy', fontsize=14)\n",
+    "\n",
+    "ind = np.arange(2)    # the x locations for the groups\n",
+    "width = 0.35         # the width of the bars\n",
+    "\n",
+    "axs[0].bar(ind, lr_mean_means, width, bottom=0, yerr=lr_mean_stds, label='mean')\n",
+    "axs[0].bar(ind + width, lr_median_means, width, bottom=0, yerr=lr_median_stds, label='median')\n",
+    "axs[0].set_title('Logistic Regression')\n",
+    "\n",
+    "axs[1].bar(ind, dt_mean_means, width, bottom=0, yerr=dt_mean_stds, label='mean')\n",
+    "axs[1].bar(ind + width, dt_median_means, width, bottom=0, yerr=dt_median_stds, label='median')\n",
+    "axs[1].set_title('Decision Tree')\n",
+    "axs[1].get_yaxis().set_visible(False)\n",
+    "\n",
+    "axs[2].bar(ind, rf_mean_means, width, bottom=0, yerr=rf_mean_stds, label='mean')\n",
+    "axs[2].bar(ind + width, rf_median_means, width, bottom=0, yerr=rf_median_stds, label='median')\n",
+    "axs[2].set_title('Random Forest')\n",
+    "axs[2].get_yaxis().set_visible(False)\n",
+    "axs[2].legend(loc='lower right', title='Imputation')\n",
+    "\n",
+    "for ax in axs:\n",
+    "    ax.set_xticks(ind + width / 2)\n",
+    "    ax.set_xticklabels(['Accuracy', 'AUROC'])\n",
+    "    ax.set_ylim([0.5, 0.85])\n",
+    "\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "naughty-tuition",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>model</th>\n",
+       "      <th>eval</th>\n",
+       "      <th>impute</th>\n",
+       "      <th>count</th>\n",
+       "      <th>mean</th>\n",
+       "      <th>std</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>median</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.689362</td>\n",
+       "      <td>0.051705</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.680851</td>\n",
+       "      <td>0.064467</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>lr</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>median</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.668617</td>\n",
+       "      <td>0.038279</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>lr</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.654255</td>\n",
+       "      <td>0.046910</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>dt</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>median</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.624468</td>\n",
+       "      <td>0.059612</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>dt</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>10</td>\n",
+       "      <td>0.596277</td>\n",
+       "      <td>0.054962</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  model eval  impute  count      mean       std\n",
+       "5    rf  acc  median     10  0.689362  0.051705\n",
+       "4    rf  acc    mean     10  0.680851  0.064467\n",
+       "3    lr  acc  median     10  0.668617  0.038279\n",
+       "2    lr  acc    mean     10  0.654255  0.046910\n",
+       "1    dt  acc  median     10  0.624468  0.059612\n",
+       "0    dt  acc    mean     10  0.596277  0.054962"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "perturbation_stats(df_metrics[df_metrics['eval'].isin(['acc'])], 'model', 'eval', 'impute').sort_values('mean', ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "asian-price",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{(mean,): <vflow.vfunc.Vfunc object at 0x7fec3fc50dc0>, (median,): <vflow.vfunc.Vfunc object at 0x7fec63785be0>}\n",
+      "{(rf,): <vflow.vfunc.Vfunc object at 0x7fec63785e50>}\n"
+     ]
+    }
+   ],
+   "source": [
+    "best_impute_set, best_model_set = \\\n",
+    "    filter_vset_by_metric(metrics, impute_set, model_set, n_keep=2, filter_on=['acc'], group=True)\n",
+    "print(best_impute_set.modules)\n",
+    "print(best_model_set.modules)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "id": "another-puzzle",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((<vflow.vset.Vset at 0x7fec3fc50ee0>,\n",
+       "  ('init',),\n",
+       "  (<vflow.vset.Vset at 0x7fec3fbffb20>,\n",
+       "   (<vflow.vset.Vset at 0x7fec3fbffa90>, ('init',)))),\n",
+       " <vflow.vset.Vset at 0x7fec3fbffa90>)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "best_impute_set.__prev__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "id": "international-place",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/james/school/yugroup/projects/pcs_inference/pcs_pipeline/veridical-flow/vflow/pipeline.py:143: UserWarning: This figure includes Axes that are not compatible with tight_layout, so results might be incorrect.\n",
+      "  plt.tight_layout()\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<networkx.classes.digraph.DiGraph at 0x7fec3f117580>"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAb4AAAEuCAYAAADx63eqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABXf0lEQVR4nO3dd1RVR/v34Q9NBARBRazBhiKgCHbEllgeNbbYK1gASwRLNCrWWDB20CQgJlFQYzQWrNFgYu8CIih2saLYaUrb7x++nl+IDRE4lPtay7Vgn12+58jiZmbvmdFQFEVBCCGEKCQ01R1ACCGEyE1S+IQQQhQqUviEEEIUKlL4hBBCFCpS+IQQQhQqUviEEEIUKlL4hBBCFCpS+IQQQhQqUviEEEIUKlL4hBBCFCpS+IQQQhQqUviEEEIUKlL4hBBCFCpS+IQQQhQqUviEEEIUKlL4hBBCFCpS+IQQQhQqUviEEEIUKlL4hBBCFCpS+IQQQhQqUviEEEIUKlL4hBBCFCra6g6QWSkpKTx69IikpCTS0tLQ0tJCT0+PkiVLoqOjo+54Qggh8gkNRVEUdYd4n4SEBGJiYnj27BkA/46roaEBQPHixSlTpgwGBgZqySiEECL/yNOFLzY2ltu3b5Oenv7BfTU1NalQoQKmpqa5kEwIIUR+lal7fE2aNCE0NBR41eIaNGgQJiYmNGjQgEOHDlGjRg3VvpUqVSI4OPiTg31M0QNIT0/n9u3baGhocOXKlffuO2zYMGbNmvXJGXPa/fv3qVmzJi9fvlR3FCGEKDA+WPi2b9+OoaEhdnZ2ABw+fJi//vqL27dvc/LkSZo2bcrFixffeuyMGTPo37//R4dKSEj4qKL32uv9ExMT37ufr68vU6dO/ehcn2r//v1UqFAh0/ubmZnRsmVLVqxYkYOphBCicPlg4fP19WXAgAGq76Ojo6lUqVKO3k+LiYkhPT2d1NTULB0fGxubzYnUp1+/fvj5+ak7hhBCFBzKe7x8+VIpWrSocuvWLUVRFGXlypWKrq6uoqmpqRgYGCjTpk1T/vnnH6V8+fKqY8zNzZW//vpL2b17t6Kjo6Noa2srBgYGSu3atRVFUZSnT58qgwcPVsqUKaOUK1dO8fT0VFJTUxVFUZRff/1Vady4sdK3b1/FyMhIGTx4sHL06FGlf//+ipmZmVKiRAnlq6++Ug4fPqycPn1aOX36tOLu7q6ULFlSKVWqlDJ16lQFULZu3aokJye/8305OTkpnp6eiqIoqvzff/+9YmpqqpQpU0bZsmWLsnPnTsXCwkIxMTFR5syZozp2+vTpSrdu3ZSePXsqxYoVU+zs7JSwsDDV64By+fLlN64VHx+vFC1aVNHQ0FAMDAwUAwMD5c6dO0paWpri5eWlVKlSRSlRooTSo0cP5dGjR6rjU1JSFD09PeXGjRvv+68SQgiRSe9t8V2+fFn10AjAkCFD8PX1pXHjxsTHxzNz5sx3Hvu///2PyZMn06tXL+Lj4zl79iwATk5OaGtrc+XKFUJDQ9m7dy8rV65UHXfy5EnKly/P3r17GTx4MMuWLSM6Opp169axZcsWYmNjVfsfPXqUNWvW8MMPP7BlyxZOnjypOs+jR48yXfxjYmJ48eIFd+7c4bvvvsPFxYU1a9Zw5swZDh06xHfffce1a9dU+wcFBdGjRw8eP35M37596dKlCykpKe+9hoGBAbt376ZcuXLEx8cTHx9PuXLl8PHxYevWrRw4cIC7d+9iYmLCyJEjVcdpa2tTrVo11ecnhBDi07y38D19+hRDQ8Nsu9j9+/fZvXs3S5cuxcDAgNKlSzNmzBjWr1+v2qd06dL06tULbW1tdHV12bJlC+PGjaN48eIYGBgwaNAg9u7dC8Bff/1Fx44dqVatGnp6eri6ugKvHsBJSkrKdC4dHR08PT3R0dGhd+/ePHz4EA8PDwwNDbG2tsba2prw8HDV/nXr1qV79+7o6OgwduxYXrx4wfHjx7P0mfj5+TFnzhwqVKiArq4uM2bM4I8//sjQzWtoaMjTp0+zdH4hhBAZvXcAu4mJCXFxcdl2sejoaFJSUihbtqxqW3p6OhUrVlR9/+/Xnjx5wosXLzI8IKMoiuohlocPH1KzZs23HpuWlpbpXCVLlkRLSwsAPT094NWDJa/p6ekRHx+v+v7feV+3iO/evZvp6/1bdHQ0Xbt2RVPz//4G0dLS4v79+5QvXx6AuLg4jI2Ns3R+IYQQGb238FlYWKAoCnfu3FH9Ev4YrweYv1axYkV0dXV5+PAh2tpvv/S/jzE2NkZXV5cNGzZQunTpN/YtVaoU9+/fV30fExOj+vp1IcsJt27dUn39ehhFuXLlANDX18/wVGlMTIyqq/i/nwe8+kx++eUXmjRp8tZrpaamcuXKFWxtbbPzLQghRKH13q5OHR0dWrVqxYEDB7J0cjMzM27cuKFqoZUtW5Y2bdowbtw4nj9/Tnp6OlevXs1wfk1NTVWB0NTUpGvXrixevJjHjx8D8ODBA44dOwZAq1at2LFjB9euXePFixf4+/sDrwrM65ZbTjhz5gybN28mNTWVpUuXoqurS6NGjQCoU6cO69atIy0tjT///DPDezMzM+PRo0eqWWjg1ZhCT09PoqOjgVdPpAYFBaleP3nyJJUqVcLc3DzH3o8QQhQmHxzO4ObmRmBgYJZO3qNHD+BVV6K9vT0AAQEBJCcnY2VlhYmJCd27d+fevXuqY/477+aoUaOoWLEigwYNonnz5owYMUJVJJo0aUKfPn0YPnw4Xbp0oV69esD/dYc+efKExMTELA+LeJfOnTvz+++/Y2JiQmBgIJs3b1bl9vb2Zvv27RgbG7N27Vq6dOmiOs7S0pI+ffpQpUoVjI2NuXv3Lh4eHnTq1Ik2bdpgaGhIo0aNOHHihOqYtWvXMmzYsGzNL4QQhVmmpixzdHRk2bJlqkHsOe3q1atZfphDURT++ecfJkyYoGo5KopCSEhItuSfMWMGV65cYc2aNZ98rg958OABzZs3JzQ0lKJFi+b49YQQojDI1OoMhw8fzukcGZQpU0bVFfqxNDU1VS3U1zVdS0sLa2vrbM2YG0qXLs2FCxfUHUMIIQqUPLken4GBARUqVMjwpGNmaGpqUrFiRXx8fDJsT0tLw9DQkGLFirF27drsjCqEECKfyZOFD8DU1PSjit+/V2do0aIFffv2BV4NRahXrx5FihShWLFipKWlfdRQh/+aMWNGrnRzCiGEyBl5tvDBq+JXvXp1jI2N0dDQeGM4wOttxsbGVK9ePcOSRP7+/tSuXZuNGzdy8uRJ1qxZg5aWFqNHj8bKyopt27aRidubQgghCpg8vR7fv2XHCuwvX75k6dKlzJkzB11dXapUqcLChQtp2rRpDqcXQgiRV+SbwpedYmJimDx5Mps2bUJHR4cGDRrg5eUlg8SFEKIQKJSF77WQkBDc3d25fv06SUlJtGvXju+++46qVauqO5oQQogckqfv8eU0e3t7Dh06xJIlSyhWrBhhYWHUr1+fkSNHZpj+TAghRMFRqAsfvHpApmfPnly8eJE+ffqgKAqnTp3CysqKKVOmZJheTAghRP5X6Avfa3p6ekyZMoWIiAgsLS3R0dHhwIEDWFhYsHDhwo9a5kgIIUTeJYXvP8qXL09AQADbtm0jJSWF0qVLs337dqpXr87KlSuzfd5PIYQQuatQP9zyIenp6axbt46JEydiZWVFfHw8jx8/Zs6cOXz11VdvXWZICCFE3iYtvvfQ1NSkf//+XLx4kUaNGhEVFUX9+vWZNWsWDRo0YN++feqOKIQQ4iNJ4csEAwMDvvvuO0JDQ1UD6Rs3bsywYcNo3bo1p0+fVndEIYQQmSSF7yOYm5uzfv161q1bx5EjRyhVqhT16tWjc+fOqidDhRBC5G1S+LKgadOmnDx5EhcXF1avXk3Lli2xsLDA0dERV1dXbt++re6IQggh3kEKXxZpaWkxePBgoqKiqFChAn5+fgwbNgwjIyNsbW2ZMGECjx8/VndMIYQQ/yGF7xMZGRkxb948Tpw4QUREBJs3b8bLy4tnz55RvXp15s6dS0JCgrpjCiGE+P+k8GWTqlWrsmXLFlauXMny5cu5ePEiP//8M+Hh4VhYWPDTTz+RkpKi7phCCFHoSeHLZp9//jkhISH07t0bV1dXjIyMCAgIICgoiJo1a/Lbb7+Rnp6u7phCCFFoSeHLAdra2gwbNoyoqCgMDAzo3bs3rVu35scff2Tp0qXY29uze/duWQhXCCHUQGZuyQVRUVGMGzeOy5cvs3DhQlJTU/H09KR06dLMmzePxo0bqzuiEEIUGlL4ctGff/7JmDFjqFixIgsWLCAkJITp06djb2/PnDlzsLa2VndEIYQo8KSrMxf973//Izw8nC+//JJWrVpx5swZjh07RrNmzWjZsiXOzs5ER0erO6YQQhRoUvhymY6ODu7u7ly4cAFFUbCzs0NHR4fz58/z2WefYW9vz+jRo4mNjVV3VCGEKJCk8KlJqVKl+OGHH/j7778JCgqiWbNmNGnShPPnz5Oenk7NmjWZOXMmcXFx6o4qhBAFitzjywMURWHbtm2MGzcOS0tLFi9ejI6ODtOnT2fv3r1MmjSJYcOGoaurq+6oQgiR70mLLw/Q0NCgc+fOREZG0rx5cxwcHFi+fDk+Pj7s3buX4OBgatSowerVq0lLS1N3XCGEyNek8OUhurq6jB8/nsjISJ4/f46lpSXHjh1j69atrFmzBn9/f2xtbQkKCpIxgEIIkUXS1ZmHhYaGMnr0aJ4+fcrSpUtp0aIFu3btYtKkSRQrVox58+bRrFkzdccUQoh8RQpfHqcoCps2beKbb76hbt26LFiwQLUu4NSpU7G0tGTu3LnUqVNH3VGFECJfkK7OPE5DQ4Pu3btz4cIF7O3tqV+/PlOmTKFTp05ERUXRvn172rVrR9++fbly5Yq64wohRJ4nhS+f0NPTw9PTk/DwcO7cuUONGjVYu3YtI0aM4PLly1hZWdGoUSNGjBjBvXv31B1XCCHyLCl8+Uz58uUJCAhgy5YtrFixggYNGnD27FmmTJlCVFQU+vr62NjY4OnpydOnT9UdVwgh8hwpfPlUw4YNOXr0KGPGjKF379706dOHxMREFi5cSFhYGDExMVSvXp0FCxaQlJSk7rhCCJFnSOHLxzQ0NOjXrx9RUVFUr14dOzs7pk+fTokSJfj55585cOAAx48fx8LCAn9/f1JTU9UdWQgh1E4KXwFgYGDAzJkzCQkJ4eLFi1haWrJ27VosLS3ZtGkTmzZt4rfffsPa2po//vhDxgAKIQo1Gc5QAB0+fJjRo0dTpEgRvL29qV+/PoqiEBwczMSJE9HQ0GDevHm0atVK3VGFECLXSeEroNLT01m9ejWenp60bt0aLy8vypUrR3p6On/88QdTpkzhs88+w8vLi/r166s7rhBC5Brp6iygNDU1GTRoEBcvXqRcuXLUrl2bOXPm8PLlS3r27ElkZCQ9e/aka9eudO/enaioKHVHFkKIXCGFr4AzNDTEy8uLkydPcubMGaysrPjjjz/Q1tbG1dWVS5cu0aBBA5o2bcrQoUO5ffu2uiMLIUSOksJXSFSpUoXNmzfzyy+/MGvWLFq0aEFYWBj6+vpMmDCBS5cuUbp0aWxtbRk/fjyPHj1Sd2QhhMgRUvgKmZYtWxISEkLfvn1p27YtLi4u3L9/HxMTE+bOncu5c+eIj4+nRo0azJkzh4SEBHVHFkKIbCWFrxDS0tLCzc2NixcvYmhoiLW1NQsXLiQ5OZly5crx008/cezYMSIiIqhWrRo//PADycnJ6o4thBDZQgpfIWZsbMzixYs5cuQI+/fvx9ramm3btqEoChYWFvz222/s2rWLHTt2ULNmTdatW0d6erq6YwshxCeR4QxCZc+ePYwZM4by5cuzZMkSbGxsVK/t37+fiRMnkpSUhJeXF+3atUNDQ0ONaYUQImuk8IkMUlJS+Omnn5g9ezY9e/Zk5syZlCxZEni1NmBQUBCTJ0+mVKlSzJs3DwcHBzUnFkKIjyNdnSIDHR0d3N3duXDhAgA1a9bEx8eHlJQUNDQ06NKlC+fOnWPw4MH06dOHzp07ExERoebUQgiReVL4xFuVLFmS5cuX888//7Bjxw5sbW35888/gVcPxzg7O3Px4kVatmzJF198gZOTEzdu3FBvaCGEyAQpfOK9rK2t2bNnD99//z2jRo2iQ4cOXLx4EYCiRYsyevRoLl++TKVKlahbty4eHh48ePBAzamFEOLdpPCJD9LQ0KBjx45ERETQsmVLmjRpwtixY1UL3RoZGTFz5swM3aPTp0/n+fPnakwthBBvJ4VPZJquri7ffPMN58+fJz4+HktLS3x9fUlLSwOgdOnSeHt7c+bMGW7cuIGFhQVLly7lxYsXak4uhBD/R57qFFkWGhrK6NGjefLkCUuXLuXzzz/P8Pq5c+eYMmUKYWFhzJw5kwEDBqClpaWmtEII8YoUPvFJFEVh06ZNjB8/Hjs7OxYuXEiVKlUy7HPkyBEmTpzI48ePmTNnDp07d5YxgEIItZGuTvFJNDQ06N69OxcuXKBevXo0aNCAiRMnEhcXp9qnSZMmHDx4kAULFjB9+nQcHBw4cOCAGlMLIQozKXwiWxQtWpTJkycTHh5OTEwMNWrU4JdfflFNcaahoUH79u0JDQ1l1KhRDB48mHbt2hEaGqrm5EKIwka6OkWOOHnyJKNHj+bly5d4e3vj6OiY4fXk5GT8/f2ZPXs2LVq0YNasWVSrVk1NaYUQhYm0+ESOaNCgAUeOHGHcuHH06dOH3r17c/PmTdXrRYoUYeTIkVy+fBkbGxsaNWrE8OHDuXv3rhpTCyEKAyl8IsdoaGjQt29foqKisLS0xM7OjmnTpmVY469YsWJ4enpy8eJFihUrRq1atZg0aZJqjKAQQmQ3KXwixxkYGDBjxgxCQ0O5cuUKlpaWrFmzJsMSRyVLlmTBggWEhYURGxuLhYUF8+fPJzExUY3JhRAFkdzjE7nuyJEjeHh4oKOjg7e3Nw0aNHhjn6ioKKZMmcLx48eZNm0agwYNQkdHRw1phRAFjbT4RK5r0qQJJ0+exM3Nja5duzJw4EDu3LmTYR9LS0v++OMPtmzZwu+//461tTUbNmyQhXCFEJ9MCp9QC01NTZydnYmKiqJChQrUrl2bOXPmkJSUlGG/+vXrs2/fPn788Ufmz59PgwYN+Ouvv5COCiFEVklXp8gTrl27xvjx4wkJCWH+/Pl07979jdldXs8S4+npSYUKFfDy8nprN6kQQryPFD6Rp+zfvx8PDw+KFy+Ot7c3dnZ2b+yTmprKr7/+ysyZM2nYsCGzZ8+mZs2aakgrhMiPpKtT5CktWrQgJCSE/v37065dO4YOHcr9+/cz7KOtrY2LiwuXL1+mUaNGNG/enCFDhnDr1i01pRZC5CdS+ESeo6WlhaurK1FRURQvXhxra2sWLFjAy5cvM+ynp6fH+PHjuXTpEmXKlKFOnTqMGzeOR48eqSm5ECI/kMIn8ixjY2MWLVrE0aNHOXjwINbW1gQFBb3xYIuxsTFz5swhIiKCpKQkatSowezZs4mPj1dTciFEXib3+ES+sXfvXsaMGUPZsmVZunQpNjY2b93vypUrTJs2jX/++QdPT09cXV0pUqRILqcVQuRV0uIT+UabNm0ICwujS5cufP7554wcOZKHDx++sV+1atVYt24du3fvZteuXW+dKUYIUXhJ4RP5io6ODl9//TUXLlxAU1MTKysrvL29SUlJeWPfOnXqsGvXLn799Vd++OEH7Ozs2Llzp4wBFKKQk65Oka9FRkYyduxYbt68yeLFi2nXrt1b91MUhW3btjF58mRKlCiBl5fXG0slCSEKByl8It9TFIWdO3cyduxYqlWrxuLFi7G0tHzrvmlpaaxZs4Zp06ZRu3Zt5s6dS61atXI5sRBCnaTwiQIjOTmZ5cuX4+XlRf/+/Zk2bRomJiZv3ffly5f4+vri5eVFmzZtmDlzJpUrV87UdVJSUnj06BFJSUmkpaWhpaWFnp4eJUuWlIm0hfx85ANS+ESB8+DBA6ZOncrWrVuZMWMGLi4uaGtrv3XfuLg4Fi9ezLJly+jbty+enp6YmZm9dd+EhARiYmJ49uwZQIZ7ha+nVytevDhlypTBwMAgm9+VyOvk5yP/kMInCqyzZ88yevRoHj58yNKlS/niiy/eue+DBw+YO3cugYGBjBw5km+++QYjIyPV67Gxsdy+fTtTT4ZqampSoUIFTE1Ns+V9iLxPfj7yFyl8okBTFIUtW7bwzTffYGtry4IFC6hWrdo7979x4wYNGjQgNTWVKVOmEB8fz6VLlxg3btxHDYfI7V9uL1++xNbWloMHD1K6dOlcuaYAa2tr5syZg7m5+Xt/Pnr27MmECROoV68eIMVP3WQ4g8jz2rZty7Rp097YHhQURJkyZUhNTX3nsRoaGnz11VecP3+eBg0a0KhRI7799lueP39OpUqVCA4OzrD/uXPnsLe35+DBgxw8eJADBw4wduzYjx4DmJ6ezu3bt0lISPio4167ceMGGhoa731v/6arq8vgwYP5/vvvs3Q9kTUnT578YNED2LBhg6ro+fn54enp+Uk/H+LTSOETeZ6zszOBgYFvjL8LDAykX79+77x/929FixZl0qRJnDt3jgcPHmBpaUl8fDxpaWkZ9vP19WXAgAHY2NiwdetWlixZkuVxf+np6cTExGTp2Kzo27cvq1evfmNOU5FzYmJisjwxQm7/fIh/UYTI4xITExUjIyPlwIEDqm2PHz9WdHV1lbCwMGXnzp1KzZo1lWLFiinlypVTFixYoNpv+/btiq2trVK8eHGlcePGytmzZxVFUZR27dopgKKhoaHo6ekp33//vfLy5UulaNGiyq1btxRFUZTk5GTF1dVVadeunXL69Gll27ZtCqBMmzZNMTMzUwwNDZWJEycqq1evVqpVq6YUK1ZM6dGjh3L69Gnl9OnTyvTp0xVbW1tlxIgRipGRkVKjRg0lKChI+e6775QNGzYo5ubmyl9//aXKOn36dKVfv36KoihKxYoVFUAxMDBQDAwMlKNHjyqKoig///yzYmlpqRgbGytt2rRRbty4keGzqlatmrJ///6c+Y8QGSQnJytly5ZVfvjhB8XFxUVp1aqV0r59e0VfX1+pUqWKEhAQoPpZeL2fj4+Poq2trWhpaSl6enqKhYWFkpycrO63UuhIi0/keXp6evTs2ZOAgADVtg0bNmBpaYmtrS1DhgzBz8+PuLg4IiIi+PzzzwEICQlh8ODB+Pn58ejRI9zc3OjUqRMvX75k165dmJubM2nSJEqVKsWZM2c4cOCA6t4L8M5VHiIiIti8eTNeXl4sXryYX375hR9//JENGzYQHBzMmTNnMuxbunRprl+/Tu3atencuTMzZszgzz//fO97PnjwIABPnz4lPj6exo0bs3XrVubOncvmzZuJjY2ladOm9OnTJ8NxNWvW5OzZsx//IYuP9t+fj4MHD9KmTRv++ecfmjVrxvz58984xsHBgUGDBtGmTRsOHTrE+vXrZTURNfhwH5EQeYCTkxMdOnRg2bJl6OnpERAQgJOTE/BqGrPz589ja2uLiYmJauyev78/bm5uNGzYUHWOuXPncvz4cZo3bw5Ay5Yt8fT0ZMGCBXTr1g0NDQ0SEhIwMDAgKSnprd2cQ4cORVdXl0aNGqGnp0fbtm0pUaIE8GqatIsXL1K3bl0ATExMaNKkCaVLl1adKz09nb179/Lo0SMmT57M4sWLAbh06RKJiYm0a9eOxMREANq3b4+m5qu/T8+cOYOZmRmjR48GXj24c+LECZo1a0bRokWBV/coIyMj2bFjx1uzZ3Vbdp4rr2/L7HGDBw/O8H2dOnVUswG1b9+e33777Y1j3nbepKSkD+4nspcUPpEvODo6YmpqSlBQEA0aNODUqVNs3rwZgE2bNjF79mwmTpxI7dq1mTdvHo0bNyY6OprVq1ezbNky1XmSk5O5e/duhnPr6+szffp0HB0dadu2LTVq1GDevHmqgvlfr4scvHqo5N/fFy1aVFW0AEqXLo2ZmRmtW7fm77//JiUlBUVRVC2zzp07q1aZX7t2Lffu3cPd3Z379+9z8OBB3N3dVfcwXV1duXr1Kjdu3FCdX1tbm65du2JlZYWGhgbTp0/Hzs6OLl26AP83fuzfsrotO8+V17dlZp//FsOSJUuqvi5atCgvX74kNTX1g/eg/3ufWeQ8KXwi3xg4cCABAQFcvHiRNm3aqAaa169fn6CgIFJSUli+fDk9e/bk1q1bVKxYEU9PTzw9Pd96vv/+ImvWrBlFihThhx9+YPbs2W/8RZ8VDx48wMDAgN27d3P37l3s7OyIjY2lcuXK3Llzh1q1atG+fXsAtm3bhoaGBu3atSM6OhqA//3vf6pfnDVr1sTLy4t+/fq983ojR46kV69eqhatyB4pKSmcP3+e06dPq/599dVXWTrXf3/utLS0siOi+Ahyj0/kGwMHDiQ4OBh/f39VN2dycjJr167l2bNn6OjoYGRkpPpF4uLigq+vLydOnEBRFBISEti5cydxcXEAmJmZce3aNdX5dXR0aNWqFQkJCZw4cYKKFSt+8l/jT548Ye3ataSkpHDkyBGSkpI4c+YMM2fOpE6dOqxfv56UlBROnz7NH3/8oTrO1NQUTU3NDPmGDRuGl5cXkZGRADx79oyNGzeqXr9z5w6PHz+mUaNGn5S5sEtLSyMiIoJVq1bx9ddf07hxY4yNjenbty8HDx5UrQjyvj9A3qdEiRLcvXuX9PR0NDQ00NPTy+Z3ID5ECp/INypVqoSDgwMJCQl06tRJtT0wMJBKlSphZGSEr68va9asAaBevXr4+/vz9ddfY2JiQrVq1Vi1apXquEmTJjF79myMjY1ZuHAhAG5ubgQGBqKpqUnbtm0zNVTifaytrZk3bx5FihShV69exMXFYW9vT3x8PLNmzeLq1auYmJgwffp0+vbtqzpOX18fT09PmjRpgrGxMcePH6dr1658++239O7dGyMjI2xsbNi9e7fqmHXr1uHk5ISuru4nZS5M0tPTiYqKYs2aNYwePRpHR0eKFy9Ot27d+Ouvv6hatSrz588nJiaGyMhIVq9ezahRo3BwcKBs2bJZumarVq0A+OKLL+jbt2+GLlKRO2TmFiH+w9HRkWXLlmFnZ8fVq1d5+vRpls6zfft2duzYQUpKCufOnVPdE6pQoQI3b958632krJKZWz4sPT2dq1evZuiuDA0NpXTp0tStW5d69epRr1497O3tKV68eKbO+Sk/HwDGxsZUrVo1y8eLrJHCJ8R7JCQkcOnSpSwNUt6xYwd79uxh79692NnZce3aNTQ1NdHR0WHAgAG4u7tjbW2dA6mFoijcuHEjQ5E7c+YMxsbGqgL3usj9++Gkj/UpPx+amppUr15dJqxWA3m4RYj3MDAwoEKFCpmegPg1TU1NSpQogaamJsWKFePvv//G1taW5ORkzp07R2BgIK1bt8bKygoPDw86dOigGrYgPo6iKNy6deuNIqenp6cqcOPHj6du3brZPjfmp/x8VKhQQYqemkiLT4hMyOzs+69fr1Sp0hu/ZENDQ7l06RK9evUCXj2Ys2HDBry9vXny5AmjRo1i0KBBGVaFEG+6e/duhiJ3+vRpNDU1qV+/vqrQ1a1blzJlyuRapo9ZneHly5fcu3ePbt265UIy8TZS+ITIpPett/Z6fN7jx49ZtGgRO3bsQF9fP1PnVRSF48eP4+3tzd69e+nfvz+jRo3CwsIiR95HfnL//v03ilxqamqG7sp69epRrly5bL1nmhWZXY8vKSmJli1bcvz4cbm/pyZS+IT4SO9aYTsiIoLRo0cTGxtLt27d+PHHHz/63Ldv3+ann37C39+fBg0a4O7uTuvWrdX+Sz03PHz4kDNnzmQocgkJCRkKXN26dfnss8/y9OeRmRXYlyxZwqZNmzhw4ICM41MDKXxCZKPU1FS8vLyYPn06/fr1Y8mSJZQqVeqjz5OUlMS6devw9vYmNTUVd3d3BgwYUGDuCT158uSNIvfkyZMMT1fWq1ePypUr5+kil1Xp6el8/vnndOjQgfHjx6s7TqEjhU+IHDBhwgSCgoJ4/Pgxnp6ejBw5UvXX/sdQFIX9+/fj4+PDoUOHGDx4MCNHjsTc3DwHUueMZ8+eERISkqHQ3b9/H3t7e+rWrUvdunWpX78+1apVK1QP+Fy/fp0GDRrwzz//YGNjo+44hYoUPiFyQEJCApaWlsydO5e1a9dy48YNFi9erJqeLCuuX7/O8uXLWbVqFS1atMDDw4OmTZvmqRZRfHw8oaGhGVpyd+7cwdbWNkNLrnr16tLFB6xcuZIff/yR48ePU6RIEXXHKTSk8AmRQ3777TcWLFjAyZMn2bNnD2PHjqVKlSosXryYmjVrZuocb7tfpKmpyZ9//snixYvR19fH3d2dPn36qFZoyC2JiYmEhYWphg+cPn2aGzduUKtWrQxFztLS8pNnwCmoFEXhyy+/pF69esycOVPdcQoNKXxC5BBFUWjatCnOzs4MHTqU5ORkfvjhB+bOnUu/fv2YPn26agml/8rME4JGRkbcuHGDRYsWERISgqurK8OHD6dcuXLZ/l5evHhBeHh4hpbclStXsLa2znBfztraOktduoXZ68nLd+zYQf369dUdp1CQwidEDjpz5gwdOnTg4sWLqmmwYmNjmTp1Klu2bGH69Om4urpmaBF9zJiw1wOhHz16xLJly1i3bh3t2rXDw8PjncsqfcjrQfb/bslFRUVRo0aNDC05GxsbmRc0m6xfv56ZM2cSEhIik1bnAil8QuSwoUOHZpgI+7Xw8HDV8IclS5bQqlWrN4re4MGDmTBhApaWlu88/+viZ2pqytOnT/nll19YtmwZJiYmfPPNN/To0eOdrbCUlBRGjRpFWFgYdnZ2HDt2jPDwcKysrGjQoIGqyNWuXTvXu1ILm169elG+fHnVwsQi50jhE+IjtG3bloYNG/Ldd99l2B4UFISbmxu3b99+437W/fv3sba25siRI9SoUSPDa4qisHXrVnr27MnYsWPp3bu3qugdPHiQjRs3ZlhI913+Pe+joigsXryYCRMmYGtry/379xk+fDhDhw7l4cOHGab1Cg8PR19fH0NDQ0aPHk29evVYtWoVtWrVYtSoUZ/4aYmP8ejRI2rXrs26detkPcUcVnieHRYiGzg7OxMYGPjG6tuBgYH069fvrQ9xmJmZMXHiRMaOHfvGaxoaGnTt2pXy5ctTs2bNDN2bmzZtyvRToOnp6cTExJCQkEC3bt2YNm0aGhoaVK9enRYtWrBs2TLKli1LkyZN2LBhQ4bldkaOHImDgwPu7u44ODjg5OSEn5/fR34y4lOVLFmSFStW4OzsrFozUuQMKXxCfIQuXbrw+PFjDh06pNr25MkTduzYwcCBA9m1axdWVlYYGhpSvnx5Vfemu7s7oaGhVKlSBWNjYxwcHAgPDwdgwIAB3Lx5k2HDhtG0aVNWr16tWpzW3t5edZ309HRWrVpF586d+eKLL5g4caLq4ZdRo0bh5+eHlZUVW7duJTExkbS0NPbs2UOdOnVwdHSkTJkyvHz5kuDgYFavXk1sbOxb7yc1bNiQa9euqVaBF7mnQ4cOfPHFF2/9I0lkHyl8QnwEPT09evbsSUBAgGrbhg0bsLS0xNbWliFDhuDn50dcXBwRERF8/vnnAERERKiK0b1793Bzc6NTp068fPmSwMBAypcvz5IlSzh06BBOTk6q9frMzMxU11m/fj379+9nxYoV7N69G0NDQ77//nvgVRfsnj176NWrF/r6+qr7cTo6OowfP56uXbsSERFBfHw8s2fP5saNGyxYsIBq1apx5MgRkpOTVdfR1tamWrVqnD17Njc+UvEfixcvJjg4mJ07d6o7SoElhU+Ij+Tk5MTGjRtJSkoCICAgACcnJ+BVoTl//jzPnz/HxMRE1WJ7vRK8lZUVvr6+qpXSjx8/Dry61/fv7tO4uLg3pifbvHkzI0aMwMzMjCJFiuDm5sa+fftITU2lZcuWXLp0iU6dOhEXF8eAAQOoX78+Xbt2BaB///6ULFkSbW1tJkyYgIaGBr6+vmzcuJH79++zdetWhg8fzoULFwAwNDT8pAVWRdYZGRnx66+/4urqyqNHj9Qdp0CSwifER3J0dMTU1JSgoCCuXbvGqVOn6Nu3L/DqvtyuXbswNzenefPmHDt2DIDo6GgWL17MkSNHGDduHMWLF+fWrVvcvXv3rdcwMjIiISEhw7Z79+4xfvx4WrRoQYsWLejevTtaWlo8fvwYAwMDHB0dCQoKQkNDg3379uHl5aW6V7do0SJq1qxJ8eLFMTY25tmzZzx8+JD69evz1Vdf0bFjR0qXLk3Lli1p27Ytd+/eleWR1KhFixb06NGDr7/+Wt1RCiQpfEJkwcCBAwkICCAwMJA2bdqouiTr169PUFAQDx48oEuXLvTs2ROAihUr4unpyfPnzxk9ejS9evUiMTGRPn36ALwx7dhnn32Goig8ePBAtc3MzAxvb2/279+v+nf06FFKly4NvOru3LlzJ8eOHVMtfQNw6NAhvv/+ezZs2MCTJ094+vQpxYsXz9DC1NPTY+bMmURHR9O7d2+io6MZM2YMy5Ytkwct1MTLy4vQ0FA2bNig7igFjhQ+IbJg4MCBBAcH4+/vr+rmTE5OZu3atTx79gwdHR2MjIxU81G6uLjg6+vLiRMnmDp1KkFBQfj4+KiKSunSpTO0/rS1tWnQoAEhISGqba+XOrp37x7w6qGa/fv3q153dHTk7t27TJs2jV69eqkmfI6Li0NbWxtTU1NSU1P57rvveP78+Vvfl66uLjVq1MDS0pLAwEAOHjyIubk5o0eP5urVq9n3AYoP0tPTIyAggFGjRqn+z0X2kMInRBZUqlQJBwcHEhIS6NSpk2p7YGAglSpVwsjICF9fX9asWQNAvXr1VPf5KleuzIsXL5g1a5aq1TV58mRWrlxJixYtCAwMBF4Vul27dqnO3adPH5o1a8bIkSNp1qwZzs7OREZGql4vUqQIXbt2JTg4WNX1Cq9agu3ataN69eqYm5tTtGhRKlas+M73tnbtWoYNG4ajoyMbN24kLCyMokWL0qhRIzp16sS+ffveGM4hckaDBg1wdXXFxcVFPvNsJAPYhVCDtLQ06taty6RJk+jVqxcAV69efeOBkiFDhjB+/Pj3ztzymrGx8Sev6P3gwQOaN29OaGjoGzO1JCYmsmbNGnx8fIBXQzT69++f6ZXmRdYkJyfTqFEjRo4cyZAhQ9Qdp0CQwieEmhw8eJABAwZw4cIF9PX1SUhI4NKlS5mao/O//j1zS05TFIW///4bb29vjh07xpAhQxg5cuR7W5Hi00RERNCyZUtOnTpFpUqV1B0n35OuTiHUpFmzZjRq1IgFCxYAYGBgQIUKFT56MdbXc3Xm1ursGhoafPHFF2zbto1jx47x8uVL6tSpQ48ePTh8+LB0yeUAGxsbxo8fj7Ozc5b+MBIZSYtPCDWKjo7G3t6e0NBQPvvsMyBrqzOYmprmdNT3iouLY9WqVfj4+GBkZIS7uzu9e/eW1RuyUVpaGs2aNaNHjx6MHj1a3XHyNSl8QqjZ9OnTuXjxIuvXr1dt+9B6fCkpKTx//hwHB4dca+llRnp6Ort378bHx4ezZ8/i5ubG8OHDKVOmjLqjFQhXrlyhUaNGHD58OFP3fcXbSeETQs0SEhKoWbMma9eupWnTphlee9sK7Hp6erRq1YrIyEimTJnCzJkzP7p7NDecP3+eZcuWsX79er788kvc3d1lodVs8OOPP7J69WqOHDkiK9tnkRQ+IfKA9evXM3/+fE6dOqUa+/c+tWvX5ty5c+jp6dGwYUM2b978ztXc1e3Jkyf8/PPPLF++nHLlyuHh4cFXX30lK7VnkaIotG3blmbNmjFlyhR1x8mXpPAJkQcoikLTpk1xdnZm6NChH9zf2tqa8+fPA6ClpUXHjh3ZsmVLTsf8JKmpqWzbtg1vb2+uXbvGiBEjcHFxoVSpUuqOlu/cvn0be3t79uzZg52dnbrj5Dt5r39EiEJIQ0MDb29vpkyZorqv9z4pKSkUKVIEgBEjRrBy5cqcjvjJtLW1+eqrrzhw4ADbt2/n8uXLWFhYMHToUNUSTSJzKlSowKJFixg4cCAvX75Ud5x8R1p8QuQhQ4cOpXjx4ixatOi9+40bNw4zMzPu3r1Lenq6alB5fhMbG4ufnx8//fQT1atXx8PDg44dO2aqu7ewUxSFbt26YWFhoVqeSmSOFD4h8pD79+9jbW3NkSNHqFGjxgf3v3fvHlZWVly8eFE1WXV+lJyczKZNm/D29ubBgwd8/fXXDB48GGNjY3VHy9NiY2OpXbs2f/zxB02aNFF3nHxDujqFyEPMzMyYNGlSplfgLlu2LL1798bb2zuHk+WsIkWK0KdPH44fP85vv/3GmTNnqFKlCiNHjuTixYvqjpdnmZqa8tNPP+Hk5ER8fLy64+Qb0uITIo9JTk7GxsaGpUuX0r59+w/uf+3aNerXr8+1a9coXrx4LiTMHXfv3uWnn35ixYoV2Nvb4+HhQZs2bfLk0A11GzhwIIaGhvzwww/qjpIvSOETIg/auXMnY8eO5dy5c6qHWN6nf//+2NjYMHHixFxIl7tevHjBb7/9hre3Ny9evGDUqFE4OTlRrFgxdUfLM54+fUrt2rX5+eefad26tbrj5HlS+ITIgxRFoX379rRu3TpT3Z4RERG0atWK69evo6enlwsJc5+iKBw6dEi1GK+zszMjR46kSpUq6o6WJ/z1118MGTKE8PBwuTf6AdJnIEQepKGhwZIlS/Dy8sqwCvu72NjY0LBhQ3755ZdcSKceGhoaNGvWjE2bNnHmzBk0NTVp0KABXbp04Z9//in0k2O3bt2ajh074u7uru4oeZ60+ITIw8aOHUt8fDwrVqz44L7Hjx+nd+/eXL58udDMipKQkEBgYCA+Pj7o6Ojg7u5O3759C2yr90MSEhKoU6cO8+fPp2vXruqOk2dJ4RMiD3v69CmWlpbs2rULe3v7D+7/+eef4+zszMCBA3MhXd6hKAp//fUX3t7enDp1iqFDhzJixAgqVKig7mi57ujRo3Tr1o2zZ8/m6yEuOUm6OoXIw4yNjfnuu+/w8PDIVFfepEmTmDdvXqFbs01DQ4M2bdqwc+dOjhw5Qnx8PLVr16Z3794cO3asUHWDOjg44OTkhJubW6F63x9DCp8QedyQIUOIj49nw4YNH9y3VatWGBgYEBQUlAvJ8iYLCwt8fHy4fv06jRs3ZsCAATRo0IA1a9aQnJys7ni5YubMmVy5coU1a9aoO0qeJF2dQuQDBw8eZMCAAVy4cAF9ff337rt582a8vLw4efIkGhoauZQw70pLS2PXrl14e3sTGRnJsGHDGDZsGGZmZuqOlqNCQ0Np27YtZ86coWLFiuqOk6dIi0+IfKBZs2Y0atSIBQsWfHDfLl26EB8fz759+3IhWd73evWK4OBg/vrrL+7evYulpSVOTk6EhISoO16OsbOzw93dnSFDhkiX539Ii0+IfCI6Ohp7e3tCQ0P57LPP3rvv6tWrWb16NX///XcupctfHj16xMqVK/nhhx8wNzfH3d2drl27FriFXVNTU2nSpAlOTk6MGDFC3XHyDCl8QuQjM2bMICoqivXr1793v5SUFKpVq8bvv/9Oo0aNcild/pOamsrWrVvx9vYmOjqakSNH4uLiQokSJdQdLdtERUXh6OjI8ePHqVatmrrj5AnS1SlEPjJhwgSOHj3KoUOH3rufjo4O48ePx8vLK5eS5U/a2tp0796dQ4cOsWXLFs6fP0/VqlVxc3MjIiJC3fGyhaWlJVOnTsXJyYm0tDR1x8kTpPAJkY/o6+szf/58PDw8PvhLbMiQIZw4caLA/ALPaXXr1mX16tVERUVRvnx5WrduTatWrdi+fXu+LxijRo1CV1eXhQsXqjtKniBdnULkM4qi0KxZMwYOHIiLi8t79/Xy8iIyMlIea8+C5ORkNmzYgLe3N48fP2bUqFEMHjwYIyMjdUfLkujoaOrVq8fff/9NrVq11B1HraTwCZEPhYSE0L59e6Kiot47IfGzZ8+oWrUqJ0+elMmcs0hRFI4fP463tzd79+6lf//+jBo1CgsLC3VH+2i//PILy5Yt48SJE5la9aOgkq5OIfIhe3t7OnbsyKxZs967X/HixXF1dc3UMAjxdhoaGjRu3Jj169cTHh6OoaEhTZo0oUOHDuzduzdfDRUYNGgQ5cuX/+DPTUEnLT4h8qn79+9jbW3NkSNHqFGjxjv3e/DgAZaWlkRGRlK2bNlcTFhwJSUlsW7dOry9vUlNTcXd3Z0BAwZgYGCg7mgfdO/ePerUqcP27dtp0KCBuuOohbT4hMinzMzMmDRpEmPGjHnvfqVLl6Zfv34sWbIkl5IVfHp6egwZMoSzZ8/yww8/sGfPHszNzRk/fjzR0dHqjvdeZcuWZdmyZQwcOJCkpCR1x1ELafEJkY8lJydTq1YtlixZQvv27d+53+vB71euXMHExCQXExYe169fZ/ny5axatYoWLVrg7u5Os2bN8uy0cX369MHMzIylS5eqO0quk8InRD63a9cuxowZw7lz5977wIKzszNVq1Zl6tSpuZiu8ImPj2f16tX4+Pigp6eHh4cHffr0oWjRouqOlsHjx4+pXbs2gYGBtGzZUt1xcpUUPiEKgPbt29OqVSvGjh37zn0uXLhA8+bNuX79er64F5Xfpaens3fvXry9vQkJCcHV1ZXhw4dTrlw5dUdT2bVrFyNGjCA8PDzfDtPICil8QhQAUVFRNG3alMjIyPcuPtqtWzeaNm3K6NGjcy+cICoqimXLlrFu3TratWuHh4cHDRs2VHcsAFxdXUlPT2flypXqjpJrpPAJUUCMHTuWuLg4/P3937nP6dOn6dq1K1evXi3U47jU5enTp6qxdKVLl8bDw4Pu3bur9f8iLi6O2rVrs3z5cjp06KC2HLlJCp8QBcTTp0+xtLRk165d2Nvbv3O/Nm3a0KtXL4YMGZKL6cS/paWlsWPHDry9vbl48SLDhw/Hzc0NU1NTteQ5cOAAffv2JTw8nJIlS6olQ26SwidEAeLv709AQAAHDx5859OE+/fvx9XVlQsXLqClpZXLCcV/hYeH4+Pjw6ZNm+jSpQseHh7UqVMn13OMHTuWO3fu8Pvvv+f6tXObjOMTogAZPHgw8fHxbNiw4Z37NG/enJIlS7Jp06ZcTCbepXbt2qxcuZLLly9TvXp1vvzyS5o3b87mzZtJTU3NtRxz5szh3LlzH1zyqiCQFp8QBcyhQ4fo168fUVFR6Ovrv3Wf7du3M23aNEJCQvLsOLPCKiUlhc2bN+Pj48OdO3cYOXIkQ4cOzZXxl6dPn6ZDhw6EhobmqadPs5u0+IQoYJo2bYqDgwPz589/5z4dOnQgNTWVPXv25GIykRk6Ojr06tWLI0eOsHHjRsLDw6lSpQrDhw/nwoULOXrtevXqMWzYMIYOHZqv5iD9WNLiE6IAunnzJnZ2doSGhvLZZ5+9dZ9169bh6+vLwYMHczmd+Fj37t3D19cXPz8/bG1tcXd3p127dmhqZn/bJSUlhYYNGzJ8+PAPLnuVX0nhE6KAmjFjBlFRUe+8Z5OamkqNGjVYvXo1jo6OuZxOZMXLly/5/fff8fb2Ji4ujlGjRuHs7IyhoWG2XiciIoKWLVty8uRJKleunK3nzguk8AlRQCUmJmJpacmaNWto1qzZW/fx8/Nj27Zt7Ny5M5fTiU+hKApHjhzB29ubffv2MXDgQEaNGkXVqlWz7RoLFixg586d/P333znSslSngvVuhBAq+vr6zJ8/Hw8PD9LS0t66j5OTE6GhoYSFheVuOPFJNDQ0cHR0ZOPGjYSFhVG0aFEaNWpEp06d2LdvX7bcnxs7dixpaWl4e3uTlJTEypUrc/Up05wkLT4hCjBFUWjWrBkDBw585/2ahQsXcvr06ULxGHtBlpiYyNq1a/H29gbA3d2d/v37v/PJ3sy4evUqdevWRU9Pj/v373Pu3Dmsra2zK7LaSItPiAJMQ0MDb29vpk6dytOnT9+6j5ubG/v27ePy5cu5G05kK319fVxcXDh37hze3t7s2LEDc3Nzvv32W27evPnR50tPT8ff35/ExERiYmIwNDTk6tWrOZA890nhE6KAs7e3p2PHjsyaNeutrxsaGjJixIj3Dn8Q+YeGhgZffPEF27Zt49ixYyQnJ2NnZ0ePHj04fPhwprtBHz9+zMqVK1X39xISErhy5UpORs810tUpRCHw4MEDrK2tOXToEJaWlm+8/ujRIywsLDh37hzly5dXQ0KRk+Li4li1ahU+Pj4YGRnh7u5O79690dXVfe9xCQkJzJs3j4ULF/LixQs6d+7M1q1bgVfDHh49ekRSUhJpaWloaWmhp6dHyZIl0dHRyYV3lXVS+IQoJBYvXkxwcDC7du166+uv1/JbvHhxbsYSuSg9PZ3du3fj4+PD2bNncXNzY/jw4ZQpU+a9x927d49evXqRkpJCcHAwMTExPHv2DCBDC/L1LEDFixenTJkyeXbdRyl8QhQSycnJ1KpViyVLltC+ffs3Xr9z5w61atXi8uXLhWKG/sLu/PnzLFu2jPXr1/Pll1/i7u5O/fr133tMbGwst2/fJj09/YPn19TUpEKFCmpbceJ95B6fEIVEkSJFWLJkCWPGjCE5OfmN18uXL0+3bt3w8fFRQzqR26ysrAgPD2fr1q3Y2trSo0cPHBwc+P3330lJSXlj/48pevCqdXn79m1iY2OzO7rKjRs30NDQ+OhhFlL4hChE2rdvT9WqVVm2bNlbX58wYQI//vgjcXFxuZxMALRt25Zp06a9sT0oKIgyZcpkeRxdpUqVCA4OzrBt+/btGBoa0rx5c7755huuXLnCN998w48//kjlypWZO3cuDx8+BF7d6/uYovfa6+KXkJCQpdw5RQqfEIXMkiVL8PLy4v79+2+8ZmFhwRdffIGfn58akglnZ2cCAwPfePIyMDCQfv36oa2tnW3X8vX1ZcCAAarvtbW1+eqrrzhw4AA7duzg0qVLWFhYMHToUG7duvXRRe+19PR0YmJisit29lCEEIXO2LFjlaFDh771tbCwMKVcuXJKUlJSLqcSiYmJipGRkXLgwAHVtsePHyu6urpKWFiYsnPnTqVmzZpKsWLFlHLlyikLFixQ7bd9+3bF1tZWKV68uNK4cWPl7NmziqIoSv/+/RUNDQ2laNGiioGBgfL9998rL1++VIoWLarcunVLdfz06dOVbt26Kf369VMMDQ0Vf39/5cqVK0rjxo2VkiVLKqampsrgwYOVEydOKKdPn1a2bNmi2NvbKwYGBkrx4sWV1q1bK6dPn1ZOnz6t9O7dWzEzM1MMDAwUS0tLZeXKlUpycrLqOt27d1f69eunFCtWTLGxsVEuXryozJ07VzE1NVUqVKig7NmzR5WrefPmysSJE5X69esrRkZGSqdOnZRHjx4piqIo169fVwAlJSVFURRFefr0qTJ48GClTJky7/2cpfAJUQg9efJEMTMzU86cOfPW19u3b6/4+vrmciqhKIoydOhQZciQIarvfX19FVtbW0VRFKVMmTLKwYMHFUV5VRBf//+dOXNGMTU1VY4fP66kpqYqq1atUszNzZUXL14oiqIo5ubmyl9//aU6Z0REhKKvr5/hutOnT1e0tbWVLVu2KGlpaUpiYqLSuXNnpX///srhw4eVvXv3KlZWVsqkSZOU06dPK23atFGGDx+unDx5Ujly5IiycuVKVeH77rvvlODgYOX48ePK6NGjlZIlSyrXr19XXUdXV1f5888/lZSUFGXAgAFKpUqVlNmzZyvJycnKihUrlEqVKqlyNW/eXClXrpxy7tw5JT4+Xvnqq6+Ufv36KYryZuHr3Lmz4urqqsTHx7/3M5auTiEKIWNjY2bNmoW7u/tbBzRPnjyZ+fPnF5i5GfMTJycnNm7cSFJSEgABAQE4OTkBr9bqO3/+PM+fP8fExAR7e3sA/P39cXNzo2HDhmhpaeHk5ISuri7Hjx9/6zWePn361hUdGjduTJcuXdDU1OT58+fs3r2byZMnU7RoUUqUKEHfvn3Zu3cv8KprNCYmhtjYWHR1dalTp47qPO3bt8fY2BhtbW369+9PcnIy58+fV73etGlT2rZti7a2Nj169CA2NpaJEyeio6ND7969uXHjRoaZhgYMGICNjQ0GBgbMmjWLDRs2vDH/7P3799m9ezdLly794DAKKXxCFFKDBw8mMTGR33///Y3XmjRpQvny5dmwYYMakhVujo6OmJqaEhQUxLVr1zh16hR9+/YFYNOmTezatQtzc3OaN2/OsWPHAIiOjmbRokUYGxur/t26dYu7d+++9RomJiZvfYCpYsWKqq+jo6NVa/O1aNGCFi1a4OXlxZMnTwBUfzQ5OTnRs2dPgoKCVMeuWbOG7t2707x5c1q0aEF8fLzqQRkAMzMz1dd6enqUKlUKLS0t1fcA8fHxb81lbm5OSkpKhvP9O2/ZsmUxNjZ+zycM2XenVAiRr2hpaeHt7U2/fv3o1KnTG5MZT548mfHjx9O7d+8CtyxNXjdw4EACAgK4ePEibdq0URWK+vXrExQUREpKCsuXL6dnz57cunWLihUr4unpiaen51vP93pg+WsWFhYoisKdO3cyzNTz7/0qVqyIrq4uZ86c4fnz52+cs1SpUkyZMgWAsLAwRowYgb29PQ8fPmT16tX89NNPVKlSBU1NTVq2bPlGho9x69Yt1dc3b95ER0eHUqVKZdj+Ou/Dhw8/+BCQ/DQLUYg1bdoUBweHt87T2bZtW3R0dGStPjUYOHAgwcHB+Pv7q7o5k5OTWbt2Lc+ePUNHRwcjIyNVK8nFxQVfX19OnDiBoigkJCSwc+dOVavOzMyMa9euqc6vo6NDq1atOHDgwDszlC1bljZt2vD999+TkJCgGppw5swZAIKDg1VPBhsaGqKhoYGmpiYJCQloaWlhbGxMWloa/v7+JCQkfHB6tPdZs2YN58+fJzExkWnTptG9e3fVe/9v3nHjxr21UP+bFD4hCrn58+ezbNkyoqOjM2zX0NBg0qRJzJ07N1vWdxOZV6lSJRwcHEhISKBTp06q7YGBgVSqVAkjIyN8fX1Zs2YNAPXq1cPf35+vv/4aExMTqlWrxqpVq1THTZo0idmzZ2NsbMzChQuBV6tyBAYGvjdHQEAAWlpa9OjRg5YtWzJhwgRVF2NkZCTOzs40bdqUsWPHMm7cOMqXL0/jxo1xcHCgW7dufPnllxQpUgQzMzOMjIyy/HkMGDAAZ2dnypQpw4sXL945yUJAQADJyclYWVm993wyZZkQgpkzZ3L+/Pk37velpaVhZWWFn58fLVq0UE84kWMcHR1ZtmwZdnZ279wnKSmJiIiIT+ruNjY2zvLq8C1atKB///4MHTo0y9f/L2nxCSEYP348x48f5+DBgxm2a2lp8e233+Ll5aWmZCInHT58+L1F759//sHW1pZt27ZlufBpamp+cBLs3CaFTwiBvr4+8+fPx8PD443HxPv378/58+dV93ZEwff48WMGDx6Mk5MTixYtYtasWVSoUOGji9/riarz2ioNUviEEAD07NmTYsWK8fPPP2fYXqRIEb755htp9RUCiqKwfv16rK2tKVasGJGRkXTs2BEAU1PTjyp+2bU6w/79+7O1mxPkHp8Q4l9CQ0Np164dUVFRGcZCJSQkUKVKFQ4cOPDWhWxF/hcdHc3w4cO5desW/v7+NGrU6K37JSQkyHp8QoiCxdXVlWLFir2xIO3s2bO5evUqv/76q5qSiZyQlpaGj48Pc+bMYezYsYwfPz5TK6jLCuxCiALjwYMHWFtbc+jQoQytuydPnlCtWjVCQ0P57LPP1JhQZJewsDBcXFwwNDTEz88PCwsLdUfKFXKPTwiRQenSpZk0aRJjx47NsN3ExIQhQ4aoxoGJ/CsxMZFvv/2WNm3aMHz4cPbt21doih5I4RNCvMXXX3/NtWvX3pi1ZcyYMaxZs4YHDx6oKZn4VMHBwdSqVYubN29y7tw5Bg8e/EnTieVH0tUphHir3bt34+HhQUREBEWKFFFtHz58OCVKlGDOnDlqTCc+1sOHDxk3bhwHDhzgxx9/pH379uqOpDbS4hNCvFW7du2wsLBg2bJlGbaPHz8ePz8/1VN9Im9TFIU1a9ZgY2NDiRIliIiIKNRFD6TFJ4R4j4sXL9KkSRMiIyMzLCXTv39/bGxsmDhxohrTiQ+5fv06w4cPJyYmBn9/f+rXr6/uSHmCtPiEEO9Uo0YNnJyc3ljuZuLEiSxdulS1WKrIW1JTU1m4cCH169enZcuWnDp1Sorev0iLTwjxXs+ePaNGjRrs3LmTunXrqrZ37tyZNm3aMHLkSDWmE/8VEhLC0KFDKVGiBH5+flmeHLogk8InhPiglStXsmrVKg4dOqR6AvD48eP07t2by5cv5/kBy4VBQkIC06dPJzAwkAULFjBgwIBC97RmZklXpxDigwYNGkRiYmKGZYsaNWpElSpV+O2339SYTADs2bMHGxsbYmJiiIiIYODAgVL03kNafEKITDl06BD9+vXjwoULqjkYg4ODcXd3/+T12kTWxMbGMmbMGI4ePcpPP/1E27Zt1R0pX5CfVCFEpjRt2pQmTZowf/581bYvvvgCAwMDgoKC1Jis8FEUhdWrV2NjY0OZMmU4d+6cFL2PIC0+IUSm3bx5Ezs7O0JCQjA3Nwdgy5YtzJ07l5MnT0r3Wi64evUqbm5uPH78mJUrV2Jvb6/uSPmOtPiEEJn22Wef4e7uzoQJE1TbOnfuTEJCAvv27VNjsoIvJSWF77//noYNG9KuXTtOnjwpRS+LpMUnhPgoiYmJ1KxZk4CAAJo3bw5AQEAAq1at4u+//1ZzuoLp1KlTuLi4YGZmhq+vL5UrV1Z3pHxNWnxCiI+ir6/PggUL8PDwIC0tDYA+ffpw7do1jh8/ruZ0BUt8fDxjxoyhY8eOjB8/nj///FOKXjaQwieE+Gg9evTAyMiIn3/+GQAdHR3Gjx+Pl5eXmpMVHLt27cLGxobHjx8TERFBv3795B5qNpGuTiFEloSGhtKuXTuioqIwNjYmKSmJypUrExwcjI2Njbrj5Vv3799n9OjRnDx5Ej8/P1q1aqXuSAWOtPiEEFliZ2dHp06d+O677wDQ09Nj9OjRzJs3T83J8idFUfjll1+oVasW5ubmnDt3TopeDpEWnxAiy2JjY7GysuLgwYPUrFmTZ8+eUbVqVU6ePEmVKlXUHS/fuHz5Mq6ursTHx+Pv70+dOnXUHalAkxafECLLTE1NmTx5MmPGjEFRFIoXL46bmxsLFixQd7R8ITk5mblz59K4cWM6d+7M8ePHpejlAmnxCSE+SXJyMrVr12bRokV06NCBBw8eYGlpSWRkJGXLllV3vDzrxIkTDB06lIoVK/LTTz+pJgQQOU8KnxDik+3evRsPDw8iIiIoUqQI7u7uFC1aNMP0ZuKVuLg4PD092bhxI0uWLKFXr17ytGYuk65OIcQna9euHdWrV8fHxweAb775hp9//pknT56oOVnesn37dqytrUlISCAyMpLevXtL0VMDafEJIbLFpUuXcHBwIDIyEjMzMwYNGkSVKlWYOnWquqOp3b179/Dw8CA0NJQVK1bQsmVLdUcq1KTFJ4TIFtWrV8fZ2RlPT08Avv32W5YtW0ZCQoKak6lPeno6/v7+2NraYmFhQXh4uBS9PEBafEKIbPPs2TMsLS3ZsWMHdevWpXv37jg6OjJ69Gh1R8t1UVFRuLm58eLFC/z9/aldu7a6I4n/T1p8QohsU7x4cWbPno2HhweKojBp0iQWLVpEcnKyuqPlmuTkZGbNmoWjoyPdu3fn6NGjUvTyGCl8Qohs5ezsTFJSEuvXr6du3bpYWVkRGBio7li54ujRo9jZ2XHy5ElCQ0MZNWoUWlpa6o4l/kO6OoUQ2e7w4cP06dOHqKgoTp06haurKxcuXCiwReDZs2dMnjyZLVu24O3tTffu3eVpzTxMWnxCiGzn6OiIo6Mj8+fPp3nz5pQqVYpNmzapO1aO2Lp1KzY2NqSkpBAZGUmPHj2k6OVx0uITQuSIW7duYWdnx5kzZwgPD2fatGmEhIQUmKJw9+5dvv76ayIjI1mxYoVqUV6R90mLTwiRIypWrIi7uzvjx4+nQ4cOpKWl8eeff6o71idLT0/H19cXW1tbbGxsOHv2rBS9fEZafEKIHJOYmEjNmjUJCAjgzp07+Pr6cvDgQXXHyrLz58/j6uqqGp9nbW2t7kgiC6TFJ4TIMfr6+ixYsAAPDw+6devGnTt3OHz4sLpjfbSXL18yY8YMmjdvTt++fTl8+LAUvXxMWnxCiBylKAotWrSgb9++AGzbto2dO3eqOVXmHTp0CFdXV2rUqMHy5cupUKGCuiOJTySFTwiR48LCwmjbti1hYWHUrVuXXbt25fl1554+fcq3337Lzp078fHx4auvvlJ3JJFNpPAJIXKFm5sb+vr6lC9fntOnT7N+/Xp1R3orRVHYvHkz7u7udOrUiXnz5lG8eHF1xxLZSAqfECJXxMbGYmVlxe7du2nXrh1Hjx7FwsJC3bEyuH37NiNHjuTy5cusWLECR0dHdUcSOUAebhFC5ApTU1MmT57MlClTGD58eJ5apDYtLY3ly5djZ2eHvb09oaGhUvQKMGnxCSFyTUpKCrVr12bq1Kl8/fXXhIeHq/1hkYiICFxcXNDW1mbFihXUrFlTrXlEzpPCJ4TIVX/++SejRo2iffv2aGlpsXjxYrXkePHiBbNnz8bPz4/Zs2fj4uKCpqZ0ghUG8r8shMhV//vf/6hRowaGhoasWrWKhw8f5nqGAwcOYGtrS1RUFGfPnsXNzU2KXiEiLT4hRK67dOkSDg4OtG3blmrVqjFz5sxcue6TJ08YP348e/bsYfny5XTu3DlXrivyFvkTRwiR66pXr86gQYNITk7Gx8eHiRMnkpqammPXUxSF33//HWtra4oWLUpkZKQUvUJMWnxCCLW4d+8eFhYWJCUloSgKt27donz58tl+nZs3bzJixAhu3LiBv78/jRs3zvZriPxFWnxCiFwXGRlJrVq1SE5OJj09HYD79+9n6zXS0tLw9vbG3t6eRo0aERISIkVPAKCt7gBCiMLH1NSUqlWrEhkZSUpKChoaGvz222/Y29tny/nDw8NxcXFBT0+PI0eOUKNGjWw5rygYpMUnhMh1pUuX5tixY8yfP5+iRYuSnp5OQEBAlu7zXbhwgREjRqAoCklJSUyaNIlWrVrh4uLC33//LUVPvEFafEIItdDU1GTEiBF8+eWXfP7552hpafHHH3/QrVs3Hj16RFJSEmlpaWhpaaGnp0fJkiXR0dHJcA5FURgwYABhYWEYGBiwZcsW6tatS3h4OGXKlFHTOxN5nTzcIoTIEyIjI0lOTub1r6R//2rS0NAAoHjx4pQpUwYDAwMA1q5di6urK4mJiWhoaBAQEED//v1zP7zIV6TwCSHULjY2ltu3b6sedHkfTU1NKlSoQJEiRShXrhyJiYkAaGlp0blzZzZt2pTTcUU+J/f4hBBq0aRJE0JDQz+q6AGkp6dz+/ZtfvnlFxITE9HX16dy5co0atTorffz9u/fn+n5QGfMmKFqMd6/f5+aNWvy8uXLzL8pkS9I4RNCANC2bVumTZv2xvagoCDKlCmT5QHmlSpVIjg4OMO27du3Y2hoSPXq1T+q6L2Wnp5O8+bNefLkCQkJCVy7do3Dhw8zd+7cLGV8GzMzM1q2bMmKFSuy7Zwib5DCJ4QAwNnZmcDAQP579yMwMJB+/fqhrZ19z8L5+voyYMAAYmJiPrrovaYoCo8ePcq2TG/Tr18//Pz8cvQaIvdJ4RNCANClSxceP37MoUOHVNuePHnCjh07GDhwILt27cLKygpDQ0PKly/PwoULVfvt2LGDOnXqYGxsjIODA+Hh4QAMGDCAmzdv0rFjR4oVK8b8+fNJTk7m77//xsHBgWfPngHg5+fHt99+y9SpU2nWrBm9evUiOjqaX3/9ldatW9OhQweOHz+uul5sbCxjxozB3t6eatWq4e/vr3otKSkJZ2dnTExMsLKy4tSpUxne5927d+nWrRumpqZUrlwZHx+fd34mDRs25Nq1a0RHR3/ahyvyFCl8QggA9PT06NmzJwEBAaptGzZswNLSEltbW4YMGYKfnx9xcXFERETw+eefAxASEsLgwYPx8/Pj0aNHuLm50alTJ16+fElgYCCfffYZ27dvJz4+ngkTJnD58mU0NTXR09PLcP1Dhw7Rvn171di7UaNGkZ6ezu7duxk6dGiGbkxPT0/MzMz4888/8fX1ZfLkyezbtw+AmTNncvXqVa5evcqePXtYvXq16rj09HQ6duyIra0td+7cYd++fSxdupQ9e/a89TPR1tamWrVqnD17Nts+Z6F+UviEECpOTk5s3LiRpKQkAAICAnBycgJAR0eH8+fP8/z5c0xMTFSzrPj7++Pm5kbDhg3R0tLCyckJXV3dDC20f3v69CmGhoaqOTpfq1OnDo0bN0ZbW5tWrVrx5MkTnJ2d0dbWpk2bNty9e5e4uDhiYmIICwtj1KhRFClShKpVqzJ06FACAwOBV8Xa09OTEiVKULFiRdzd3VXXOHXqFLGxsUybNo0iRYpQpUoVXFxcWL9+/Ts/E0NDQ54+ffpJn6vIW6TwCSFUHB0dMTU1JSgoiGvXrnHq1Cn69u0LwKZNm9i1axfm5uY0b96cY8eOARAdHc2iRYswNjZW/bt16xZ379596zVMTEyIi4sjLS0tw/aSJUuqvtbV1cXY2BgtLS3V9wCJiYk8fPgQIyMj1Vi+tLQ0zM3NuXPnDvCqK7NixYqqc5mbm6u+jo6O5u7duxmyzp07973zhMbFxWFsbJypz0/kDzJzixAig4EDBxIQEMDFixdp06YNZmZmANSvX5+goCBSUlJYvnw5PXv25NatW1SsWBFPT088PT3fer7Xg89fs7CwQFEUYmNjKVKkyEfnK1WqFM+fPychIQEDAwO0tLS4efOmamWHsmXLcuvWLaytrYFXqzO8VrFiRSpXrszly5czda3U1FSuXLmCra3tR+cUeZe0+IQQGQwcOJDg4GD8/f1V3ZzJycmsXbuWZ8+eoaOjg5GRkao15uLigq+vLydOnEBRFBISEti5cydxcXHAq2EB165dU51fR0eHVq1aERoa+kZRzIwyZcpQu3Ztli9fTnJyMtevX+fnn3+mX79+APTs2RMvLy+ePHnC7du3WbZsmerYBg0aYGRkxPfff6+aEi0iIuKNB2BeO3nyJJUqVcrQahT5nxQ+IUQGlSpVwsHBgYSEBDp16qTaHhgYSKVKlTAyMsLX15c1a9YAUK9ePfz9/fn6668xMTGhWrVqrFq1SnXcpEmTmD17NsbGxqonQd3c3Ni2bVuWM86ZM4d79+7xv//9DxcXF2bOnEnr1q0BmD59Oubm5lSuXJk2bdowYMAA1XFaWlps376dsLAwKleuTKlSpRg6dKjq6dL/Wrt2LcOGDctyTpE3yZRlQgi1cHR0ZMKECZ+0+KyxsTFVq1bNxlT/58GDBzRv3pzQ0FCKFi2aI9cQ6iGFTwihNgkJCVy6dClLg9g1NTWpXr266iEXITJLujqFEGpjYGBAhQoV0NT8uF9FryeqlqInskIKnxBCrUxNTT+q+L0ueqampjmcTBRU0tUphMgTEhISiImJUT1okpn1+ITICil8Qog8JSUlJdMrsAuRFVL4hBBCFCpyj08IIUShIoVPCCFEoSKFTwghRKEihU8IIUShIoVPCCFEoSKFTwghRKEihU8IIUShIoVPCCFEoSKFTwghRKEihU8IIUShIoVPCCFEoSKFTwghRKEihU8IIUShIoVPCCFEoSKFTwghRKEihU8IIUShIoVPCCFEoSKFTwghRKEihU8IIUShIoVPCCFEoSKFTwghRKHy/wCK9CFFZHsrpwAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "build_graph(best_impute_set)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "id": "elementary-syndicate",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<networkx.classes.digraph.DiGraph at 0x7fec3f117d30>"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAb4AAAEuCAYAAADx63eqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABOxklEQVR4nO3deVzN6f8//kfLadWuJKWMBqlkS/ZCGHsZEyplz26Wt22yjm2yje07orFV9hFNZAtlGamsLbYRKUnRftpO51y/P/x6fUSSnDrndJ73281tdHotz3OMHq7XtSkwxhgIIYQQOaEo6QIIIYSQ+kTBRwghRK5Q8BFCCJErFHyEEELkCgUfIYQQuULBRwghRK5Q8BFCCJErFHyEEELkCgUfIYQQuULBRwghRK5Q8BFCCJErFHyEEELkCgUfIYQQuULBRwghRK5Q8BFCCJErFHyEEELkCgUfIYQQuULBRwghRK5Q8BFCCJErFHyEEELkCgUfIYQQuULBRwghRK4oS7oAQqSFQCDA27dvUVxcDKFQCCUlJairq8PAwAA8Hk/S5RFCxESBMcYkXQQhksTn85GRkYG8vDwAwPt/JRQUFAAAOjo6MDY2hqampkRqJISIDwUfkWtZWVlIS0uDSCT67LGKioowNTWFoaFhPVRGCKkr1MdH5FZVoTdx4kQ8fPiwyuNFIhHS0tKQlZX1Vfddvnw5PD09AQCvX7+GlZUVSktLv+qahJCao+AjUm3gwIFYunTpR6+HhobC2NgY5eXltbquubk5jh8/Xin0rly5Ak1NTbRp0+aT51WEH5/Pr9V9P9SkSRP06dMHu3btEsv1CCGfR8FHpNr48eMRFBSED5/IBwUFwcPDA8rKtRufJRQKP3q8efz4cQwePPiz54pEImRkZNTqvlXx8PDAzp07xXY9Qkj1KPiIVHNxcUF2djauXr3KvZaTk4NTp07By8sL4eHhaNu2LbS0tNCsWTNs2LCBO+7UqVNo3749dHV10b17d9y/fx/Au6BJT0/Hzz//jF69emH//v0QCASIi4tDx44dufNFIhH27duHESNGoF+/fli4cCE3AGbcuHHYsmVLpVrt7OwQEhICAJg7dy7MzMygra2NTp06Var/Qw4ODkhOTkZKSsrXf2CEkM+i4CNSTV1dHW5ubggMDOReO3r0KNq0aQM7OztMmjQJO3fuREFBARISEtC3b18AwO3btzFx4kTs3LkTb9++hY+PD4YPH47S0lJs3LgRxsbG2LRpE65evQpvb2+8ePECCgoKaNKkCXefw4cPIzIyErt27cKZM2egpaUFPz8/AMB3332HAwcOcMcmJSUhJSUFQ4YMAQDY29vj7t27yM7Ohru7O3744QeUlJRU+R6VlZVhaWmJe/fuif3zI4R8jIKPSD1vb28cO3YMxcXFAIDAwEB4e3sDAHg8HpKSkpCfnw89PT2uxRYQEAAfHx84ODhASUkJ3t7eUFVVRXR0NHed9xUUFHw0VSEkJAQzZsxAkyZNoKKiAh8fH1y8eBHl5eVwcnJCQkIC10o7cOAARo4cCVVVVQCAp6cnDAwMoKysjF9++QWlpaV49OjRJ9+jlpYWcnNzv/qzIoR8HgUfkXo9e/aEoaEhQkNDkZycjNjYWLi7uwN41y8XHh4Oc3NzODo64saNGwCAlJQUbNy4Ebq6utyv1NRUpKenQygUfnQPbW3tjwasvHr1CvPmzYOTkxOcnJwwatQoKCkpITs7G5qamnBycsLhw4cBvGsdenh4cOdu3LgRVlZW0NHRga6uLvLy8vDmzZtPvseCggLo6up+7UdFCKkBWrmFyAQvLy8EBgbi0aNHGDBgAPdI0t7eHqGhoRAIBNi+fTvc3NyQmpoKMzMz+Pr6wtfX96NrPXv2jJuYXqF58+ZgjCEzMxNGRkYA3o24XLp0Kdq3b19lTZ06dcLevXvRs2dPFBcXo0+fPgCAq1evws/PDxcvXoS1tTUUFRWhp6f30QCdCuXl5fjvv/9gZ2dX24+HEPIFqMVHZIKXlxciIiIQEBDAPeYsKyvDgQMHkJeXBx6PB21tbSgpKQEApkyZAn9/f9y8eROMMfD5fJw+fRoFBQVQV1eHvr4+Xr58yV1fWVkZXbp0we3bt7nXvv/+e/z555949eoVgHeDaiIjIwG8G/iip6eHJ0+eoE+fPtDQ0MC2bdtw9+5d5OXlQVlZGYaGhigvL8dvv/2G/Pz8T763mJgYWFhYwNzcXNwfGyGkChR8RCZYWFige/fu4PP5GD58OPd6UFAQLCwsoK2tDX9/fwQHBwMAOnfujICAAMyaNQt6enqwtLTEvn37AAAGBgaYMGECdu/eDScnJwQFBQF4F3Th4eHctceOHYvevXtj5syZ6N27N8aPH4/ExEQAgJKSEmbPno3x48dDIBDAy8sLiYmJGD16NMaNGwcejwcLCwuYmJhARUUFZmZmn3xvBw4cwLRp08T9kRFCPoGWLCNy6enTp1UOJpk0aRLmzZtX7SR2ANDV1UXLli2r/N6rV68QFRXF/UpPT0ePHj3g6OgIJycndOzYkZt/mJmZCUdHR9y5cwdqampf/b4IIZ9HwUfkRnl5ORISEnD58mXEx8dj9uzZNVqj80OKiopo1apVjReszszMxJUrVxAVFYXIyEikpKSge/fucHR0hKOjIzp37gwVFZUvroMQUjsUfKTBe/jwIcaOHYukpCQoKyujqKgIjRs3RlJSUo0XqK4gjoWq37x5g6tXr3Itwv/++w8ODg5wcnKCo6MjunTpwk2LIISIHwUfafAyMzNhZWWF7OxsAICqqioOHToEV1dXqdidIScnB9euXUNkZCSioqLw8OFD2Nvbcy3Crl27Ql1dXaz3JESeUfCRBk8oFGL8+PE4cOAAGGMwMTHBixcvuBGg0rYfX15eHq5fv861CBMSEtCxY0cuCLt160b7AhLyFSj4SIOWnZ2NsWPHQigUYsiQIfj555/h7+8PHx+fj46t2IGdz+fjzJkz6Ny5MywsLCS+A3thYSH+/fdfrkV47949tGvXjhss0717d2hpaUmsPkJkDQUfabDu378PV1dXjBw5EmvXroWysjLCwsIwYMCAavvQjhw5gjFjxsDW1hb37t37aLK7pBUVFeHGjRtci/DWrVuwtrbmWoQ9e/aEjo6OpMskRGpR8JEG6ejRo5g5cya2bt2KsWPHftG5NjY2SExMhJqaGo4dO4ahQ4fWUZXiUVxcjJs3b3JBGBMTg9atW3Mtwl69ekFPT0/SZRIiNSj4SIMiFArx66+/4ujRozhx4sQnlxv7lOjoaPTr1w9FRUUAAFNTUyQnJ0v0UeeXKi0tRWxsLDd9Ijo6Gi1btuRahL1790bjxo0lXSYhEkPBRxqM9/vzDh8+XKsf7jNmzMCuXbvAGANjDMrKyrh58yY6dOhQBxXXj7KyMty6dYtrEf77778wMzPjpk/07t270nZMhDR0FHykQajoz3N1dcXvv/9e653ZCwsL8fbtWyxYsADOzs6YPHmymCuVvPLycty5c4cbLHPt2jU0bdqUaxE6OjrCxMRE0mUSUmco+IjMq+jP27JlC7dd0deaNWsW2rRpg1mzZonletJMKBTi3r17XIvwypUraNy4caUgrG6tUUJkDQUfkVlf259XnUWLFkFbWxuLFi0S2zVlhUgkQnx8fKUg1NLS4gbLODo6wsLCQtJlElJrFHxEJomjP686q1evBp/Px5o1a8R6XVkkEonw4MEDLggjIyOhpqZWqUXYsmVLqZv2Qcin0LZERObEx8fD3t4etra2OHv2bJ2MUNTS0kJBQYHYryuLFBUVYW1tjRkzZuDIkSPIyMjAuXPn0KNHD1y8eJF7FOrh4YFdu3bh0aNHn9x0lxBpQC0+IlOOHj2KWbNmYfPmzWLrz6vK3r17ERUVxe3hRz6NMYanT59WahEKBAL07t2baxG2bduWWoREatRu6Bsh9UwoFMLX1xdHjhzB+fPnxdqfVxUtLS0UFhbW6T0aCgUFBVhaWsLS0hKTJk0CYwzPnz/ngnDDhg0oLCysFIQ2NjZQVKQHTkQyKPiI1MvOzoa7uzsEAgFiY2PrZfJ1o0aN6FFnLSkoKKBFixZo0aIFxo8fDwBITU3lWoNbt25FdnY2evXqxQWhnZ0dt2g4IXWNHnUSqRYfHw8XFxe4uLjAz8+v1vPzvtT169cxb948/Pvvv/VyP3nz8uVLbnPeqKgoZGRkoGfPnlwQdujQod7+rIn8oeAjUqsu5ufV1P379+Hh4YH4+Ph6va+8ysjIqBSEqamp3C71Tk5O6NSpk0wtG0ekGwUfkTrv9+eFhIRIZLmwZ8+eoU+fPnj+/Hm935sAWVlZ3C71kZGRePbsGbp27cq1CO3t7WmXelJrFHxEqrzfn3fkyBGJLaaclZUFKysrvHnzRiL3J5VlZ2dzQRgVFYVHjx6hS5cu3IR6BwcHqKmpSbpMIiMo+IjUkFR/XlVKSkqgo6OD0tJSidVAPi0vLw/Xrl3j1htNSkpCp06dKu1Sr6GhIekyiZSi4CNS4dixY5gxY4ZE+vOqwhiDiooK+Hw+VFRUJF0O+YyCggJcv36daxHev38f7du354Kwe/fuaNSokaTLJFKCgo9IlFAoxOLFi3H48GGJ9ed9ir6+Pp48eQIDAwNJl0K+EJ/Px40bN7gW4Z07d2BjY8MNlunRowe0tbUlXSaREAo+IjHS0p/3Kebm5oiKiqIFmRuA4uJiREdHcy3C2NhYWFlZcS3CXr16QVdXV9JlknpCwUckIj4+Hq6urhgxYoTE+/M+xdraGkeOHIGNjY2kSyFiVlJSgpiYGC4Ib968CUtLS26wTK9evail34BR8JF6V9Gft3nzZnh4eEi6nE/q2rUr/vjjD3Tr1k3SpZA6VlZWhri4OO7R6I0bN2BhYcG1CHv37g0jIyNJl0nEhIKP1Btp7s+rSv/+/TFv3jwMGDBA0qWQeiYQCHD79m2uRXj9+nWYmJhwLUJHR0cYGxtLukxSSxR8pF5Ie39eVUaOHAkPDw98//33ki6FSFh5eTnu3bvHtQivXr0KIyOjSnsSmpqaSrpMUkO0PDqpc/Hx8ejSpQvatm2Lc+fOyUToAbRQNfk/ysrK6NSpE3755Rf8888/ePPmDY4cOQJra2scP34c7du353anCAwMREpKiqRLJtWgFh+pU7LSn1eVmTNnok2bNpg9e7akSyFSTiQSITExkXs0GhUVBQ0NjUqPRlu0aEF7EkoJCj5SJ2StP68qCxcuhI6ODhYtWiTpUoiMYYzh4cOHlTbnVVZWrvRo9Ntvv6UglBDpG0NOZF5OTg7Gjh1br/vn1QUtLS161ElqRUFBAVZWVrCyssK0adPAGMOTJ0+4IPztt98gFAorBWGbNm0oCOsJ9fERsUpISIC9vb3M9edVhYKPiIuCggJatWqFKVOmIDg4GC9evMC1a9cwYMAA3LhxA4MGDYKxsTF++OEHbN++HfHx8RCJRJIuu8GiFh8Rm7///hszZszAH3/8IXP9eVWhwS2krigoKOCbb77BN998gwkTJgAAUlJSuBbh5s2bkZubi969e3Mtwnbt2kFRkdoq4kB9fOSrCYVCLFmyBAcPHkRISAg6duwo6ZLE4tixYzh8+DCOHz8u6VKIHEpLS6s0WCYrK4vbpd7JyQnt27eHkpKSpMuUSdTiI18lJycH7u7uKC0tRWxsLAwNDSVdkthoaWmhsLBQ0mUQOWVqagoPDw/u6cmrV6+4Xep3796N9PR09OjRg2sRduzYsV53qRcIBHj79i2Ki4shFAqhpKQEdXV1GBgY1GsdtUEtPlJrCQkJcHFxwfDhw7Fu3TqpXG/za1y/fh3z5s3Dv//+K+lSCPlIZmYmF4RRUVF4/vw5unXrxrUIO3fuXCdbavH5fGRkZCAvLw/AuxGsFSoG5+jo6MDY2Biamppiv784UPCRWvn7778xffp0/PHHH/D09JR0OXXi3r178PT0RHx8vKRLIeSz3r59y+1SHxkZif/++w8ODg5ci9DBwQGqqqpfdY+srCykpaXVaOCNoqIiTE1NpfIpEAUf+SINtT+vKsnJyejbty+eP38u6VII+WI5OTm4du0a1yJ88OAB7O3tuSDs2rUr1NXVK52zYcMGtGzZEq6urh9d70tCr4K0hh8NESI1lpOTg6FDhyI6OhqxsbENOvQA6uMjsqFHjx64c+cOgHePHSdMmAA9PT0MHDgQurq6CAsLQ2xsLNLT05GUlIQHDx5g0aJFMDQ0RK9evbB48WJcuHABhYWFWLt2LcaOHYvVq1dXeoTJ5/O/OPSAdyvapKWlgc/nA3j3KPS///4T35uvJQo+UiMV8/OsrKxw/vx5qfsXXF2geXykNgYOHIilS5d+9HpoaCiMjY1RXl5eq+taWFggIiKi0mthYWHQ0tLiVka6du0aLly4gLS0NMTExKBXr1549OgRAEBbWxvq6uqYMmUKoqOjMWfOHKioqIAxhhUrVsDIyAi5ubkoLS3FypUrMWbMGAgEAgBARkZGrecVikQiZGRk1OrcukLBRz7r+PHj6Nu3L5YvX45NmzY1uEEsn6KqqgqRSISysjJJl0JkyPjx4xEUFIQPe5GCgoLg4eEh1r8//v7+GDduHPd1SkoKLCwsajSoREVFBU2bNsXq1atx7do1bNq0iRuNWVpaiqNHj6Jnz54QCATcQJb3fUmA5+XlcSEqFRghn1BeXs4WLVrEzM3N2a1btyRdjkTo6uqyN2/eSLoMIkOKioqYtrY2i4qK4l7Lzs5mqqqq7O7du+z06dPMysqKNWrUiJmYmLD169dzx4WFhTE7Ozumo6PDunXrxu7du8cYY8zT05MpKCgwNTU1pqmpyfz8/FhpaSlTU1NjqampjDHG/vrrL6aqqsoUFRWZpqYmW7p0Kbt8+TJr1qwZd31zc3N24cIFdubMGcbj8ZiysjLT1NRk7dq1Y9OnT2cKCgpMR0eHaWhoMD09PTZz5kyWlpbGbt26xZYtW8batWvHxo4dy7S1tdnEiRPZv//+yzw9PVmTJk2Yvr4+GzlyJLt27RqLi4tjcXFxbM6cOczAwIA1btyYbdq0iQFgT548qfbz8/b2ZtOnT2ffffcd09TUZN27d2evXr1ic+fOZbq6uqx169bs9u3b3PFJSUnM0dGR6ejosLZt27LQ0NDP/hlR8JEqZWdns0GDBrE+ffqwzMxMSZcjMWZmZuzZs2eSLoPImMmTJ7NJkyZxX/v7+zM7OzvGGGPGxsbsypUrjLF3f88q/lF569YtZmhoyKKjo1l5eTnbt28fMzc3ZyUlJYyx/wutCgkJCUxDQ6PSfffu3ct69OjBff2p4GOMsWXLljEPDw/uezk5OWzIkCFs6tSprLCwkL1+/ZrZ29uzVatWsbi4OLZs2TKmpKTE/ve//7Ho6Gh27do1NnbsWNarVy928eJFFhUVxXr16sXGjx/P4uLi2NatW5m+vj47fPgwu3r1Khs2bFiNg8/AwIDFxcWx4uJi1qdPH2ZhYcH279/PysvLma+vL3NycmKMMVZWVsZatmzJVq9ezUpLS9nFixdZo0aN2MOHD6u9Bz3qJB9JSEhAly5d0Lp1a7npz/sUGuBCasPb2xvHjh1DcXExACAwMBDe3t4AAB6Ph6SkJOTn50NPT48bJBYQEAAfHx84ODhASUkJ3t7eUFVVRXR0dJX3yM3NhZaWlthqHjduHE6fPo3MzEyEh4dDTU0NP/30E8LCwrhjGjdujDFjxkBZWRmqqqo4ceIEfvnlF+jo6EBTUxMTJkzA+fPnAQAXLlzAsGHDYGlpCXV19S/a3svV1RWdOnWCmpoaXF1doaamBi8vLygpKWH06NHcYJ7o6GgUFhZi4cKFUFFRQd++fTF06FAcOnSo2uvLR2cNqbHjx49j2rRp2LRpU6W+A3lFA1xIbfTs2ROGhoYIDQ1Fly5dEBsbi5CQEADv/o6tWrUKCxcuRLt27fD777+jW7duSElJwf79+7Ft2zbuOmVlZUhPT6/yHnp6emL9f1NDQwMAcPLkSZw8eRLAu5C2sLDgjmnSpAn3+5ycHJSUlFSax8sY4wbBvHnzBlZWVtz3zMzMalzL+/dRV1f/6OuKf4ymp6fDzMys0hqm5ubmePnyZbXXp+AjACrPzzt37lyDn6pQU7RQNaktLy8vBAYG4tGjRxgwYAD3w9ve3h6hoaEQCATYvn073NzckJqaCjMzM/j6+sLX17fK6324ZdG3334LxhhevnyJZs2a1biusrIy3Lt3D/Hx8Xj48CGGDh2KhISESgGroqKCVq1a4Z9//oG6ujr3vfdr0NXVhaqqKo4ePQojI6OP7tO4cWO8fv2aOy87O7vGNdaUiYkJUlNTIRKJuPB78eIFWrVqVe159KiTICcnB8OGDcONGzfkYn7el6AWH6ktLy8vREREICAggHvMWVZWhgMHDiAvLw88Hg/a2trcQtNTpkyBv78/bt68CcYY+Hw+Tp8+zf3/16RJEyQnJ3PX5/F4cHZ2RlRUVJX3FwqFSEtLQ3FxMX777Te4ubkhPT0dLi4uGDt2LJ4/f47CwkJMmDABFy5cQExMDBQUFKCkpIRFixbhzp073M7yVVFUVISrqys2bdrEhVpmZiZu3LgBAHB2dsapU6eQnJyM4uJibN++XTwf7HscHBygqamJdevWQSAQIDIyEmFhYRgzZky151Hwybn3+/MuXLgg1/15VaE+PlJbFhYW6N69O/h8PoYPH869HhQUBAsLC2hra8Pf3x/BwcEAgM6dOyMgIACzZs2Cnp4eLC0tsW/fPu68RYsWYdWqVdDV1cWGDRsAAD4+PggKCsLLly9x9uxZnDlzBk+ePEGnTp2gra2N//3vfygqKkJxcTFGjBgBQ0NDnDx5EklJSTh//jzMzMwwefJkjB49Gm3btkXfvn0xfPhw/PXXXzAwMMCoUaOQlZUFHR2dKt/j7NmzYWZmhgkTJsDR0REzZsxASkoKgHcT68eOHYvp06dj5MiRcHZ2FvtnrKKign/++QdnzpxB48aNMWPGDAQGBqJNmzbVnkdLlskx6s/7vJkzZ8LKygqzZs2SdCmEIDs7GwkJCdyv+Ph43LhxA9ra2ujQoQNsbGxga2sLGxsbtG3bFtra2mK5L5/Px+PHj2s1iV1RURGtWrWSqgWrqY9PDgmFQixduhQHDhyg/rzPoEedRBKKioqQlJTEhVtF0OXn58PGxoYLuFGjRsHGxqbKPjZx0tTUhKmpaa3X6pSm0AMo+ORObm4u3N3dUVxc3OD2z6sLNLiF1CWBQIAnT558FHBpaWlo1aoV13qbPXs2bG1t0bx5848GudSXip8V4tidwdramnsk+r6dO3dy+w/WJQo+OZKYmAgXFxcMHToU69evl5ulx76GlpYWNzKNkNoSiUR48eLFRwH3+PFjmJmZca24sWPHwtbWFpaWllK5mauhoSE0NDS+ej++Tw2YqS/0k09OUH9e7dDgFvKlMjMzK4VbfHw8EhMToaOjwwXcgAED8PPPP8PKyoqbPycrNDU10bJlS5negZ2Cr4Gr6M8LDg7G2bNn0alTJ0mXJFOoj498Sn5+PhITEysFXEJCAgQCAWxtbWFra4uOHTvCy8sL1tbW0NfXl3TJYsXj8WBsbCzpMmqFgq8Be78/Ly4ujvrzaoH6+EhpaSkePnz4UcBlZWXBysqK64cbPHgwbG1t0bRpU4n1w5GaoeBroCr684YMGYL169dL/aMHaUUtPvkhFAqRnJz8UT/cs2fP8M0333CPKSdPngwbGxu0aNGCm3xOZAsFXwNE/XniQ318DQ9jDOnp6R8F3IMHD2BkZMQFnIuLCxYvXozWrVtDVVVV0mUTMaLga0CoP0/8qMUn26qa8J2QkAAVFRVuLlzPnj0xbdo0WFtbi3W3AyK9KPgaCOrPqxsUfLLh/Qnf7wdcQUEBrK2tuX64+prwTaQbLVnWAFB/Xt0pLi6Grq4uSktLJV0KQeUJ3+8HXFpaGlq3bl1pVRMbGxuJTvgm0ouCT8aFhITAx8cHGzduhJeXl6TLaXAYY+DxeCgqKoKKioqky5Eb1U34NjU15YKt4r/SOuGbSCcKPhklFAqxbNkyBAUFISQkhPrz6pCenh6ePn3a4OZhSYsPJ3wnJCQgMTER2tralcLNxsZGJid8E+lDfXwyKDc3Fx4eHuDz+YiNjaX+ijpW0c9Hwfd1PjXhu7y8nAu4ignfNjY20NPTk3TJpIGi4JMxFf15gwcPxoYNG+jxTj2gSexf5v0J3++35LKystC2bVuu9TZkyBDY2NjQhG9S7yj4ZAj150kGjeysGk34JrKKgk8GvN+fR/Pz6p+8T2KvmPD94cLLDx8+5CZ829ra0oRvIjMo+KQc9edJnjy1+GjCN5EHFHxSjPrzpEND7OP71A7fNOGbyAMKPilV0Z+3YcMGeHt7S7ocuaatrQ0+ny/pMmqlYsL3h9MFPpzwPWfOHJrwTeQGzeOTMiKRCMuWLUNgYCCOHz+Ozp07S7okuVWx0eabN2+gqKgIdXV1qd1oUyQSISUl5aPHlE+ePKm0wzdN+CaEgk+qVPTnFRYW4tixY/R4SUL4fD4yMjKQl5cH4N3gjgoVrSEdHR0YGxtDU1Oz3ut7/fr1R31w7+/wTRO+CakeBZ+USEpKgouLC7777jts3LiR/jVez3r06IHt27fD1NQUaWlpEIlEnz1HUVERpqamX7QgeGRkJDw9PZGWlvbZYxctWoTbt2/j+++/R0xMDA4dOgQNDQ0IhcKPAo4mfBNSc9THJwVOnDgBHx8frF+/nvrz/n8DBw6Eg4MDfvvtt0qvh4aGwsfHB2lpaVBW/vL/fS0sLPDXX3/B2dmZey0sLAxaWlpfFHrAu8eLFQH2NbthlJaW4sGDBx89pkxPT4e2tjZMTExgY2ODvn37wsHBAb6+vtQPR8hXoOCToPf788LDw6k/7z3jx4/Hr7/+ihUrVlT6IR8UFAQPD49ahd6n+Pv7w83N7YtCr0JF+GloaHz2sadQKERqaiqKi4vx22+/cY8pnz17hpYtW3404TswMBDJycnYu3cvAKBr167w8fHB4sWLa/1eCSGAoqQLkFe5ubkYNmwYrly5gtjYWAq9D7i4uCA7OxtXr17lXsvJycGpU6fg5eWF8PBwtG3bFlpaWmjWrBk2bNjAHXfq1Cm0b98eurq66N69O+7fvw8AGDduHF68eIFhw4ahUaNGWLduHcrKynDp0iW0atWKC72dO3diwYIFWLJkCXr37o3Ro0cjJSUFe/fuRf/+/TFkyBBER0dz93v9+jWGDx8OfX19WFpaYteuXUhLS8PZs2exZs0aWFpaQllZGTweD3PnzkVRURFKSkrg6uqKbdu2YdCgQcjMzERMTAx0dHTg4uICS0tLKCpW/uvp4OCA5ORkpKSk1OVHT0iDR8EnAUlJSejSpQtatmyJiIgIGsRSBXV1dbi5uSEwMJB77ejRo2jTpg3s7OwwadIk7Ny5EwUFBUhISEDfvn0BALdv38bEiROxc+dOvH37Fj4+Phg+fDhKS0sRFBSE5s2bIywsDIWFhZg/fz6ePHkCRUXFjwaAXL16FYMHD8alS5fQunVrzJ49GyKRCGfOnMHkyZOxZs0a7lhfX1/o6enBw8MDWlpamDZtGmxtbbF+/XqEhIRAQUEBp0+fRmJiIkxMTGBgYIA1a9ZgzJgxWLBgATp06ICXL1/i4sWL2Lx5M86dO1flZ6KsrAxLS0vcu3evDj5xQuQHBV89O3HiBBwdHfHrr79i69atNIilGt7e3jh27BiKi4sBAIGBgVwfKI/HQ1JSEvLz86Gnp4eOHTsCAAICAuDj4wMHBwcoKSnB29sbqqqqlVpo78vNza3yEWX79u3RrVs3KCsrw9nZGTk5ORg/fjyUlZUxYMAApKeno6CgABkZGbh79y5mz54NR0dHbNy4EbNmzcKIESNw8eJFZGdnY9u2bRg4cCCsrKwwZ84c7h6xsbHIysrC0qVLoaKigm+++QZTpkzB4cOHP/mZaGlpITc3t7YfKSEEFHz1RiQSYcmSJZg7dy7Cw8Mxfvx4SZck9Xr27AlDQ0OEhoYiOTkZsbGxcHd3BwAcP34c4eHhMDc3h6OjI27cuAEASElJwcaNG6Grq8v9Sk1NRXp6epX30NPTQ2FhIT4c3GxgYMD9XlVVFbq6utwCyxXrUBYVFeHNmzfQ1tZGo0aN0KlTJ/Tt2xdt27bFy5cvAQDp6ekwMzPjrmVubs79PiUlBenp6ZVqXbNmDV6/fv3Jz6SgoAC6uro1/QgJIVWgwS31IDc3F56enigoKEBsbCyaNGki6ZJkhpeXFwIDA/Ho0SMMGDCA++zs7e0RGhoKgUCA7du3w83NDampqTAzM4Ovry98fX2rvN6HoyG//fZbMMaQmZlZq0fOjRs3Rn5+Pvh8PnR0dAAAL168QLNmzQAATZs2RWpqKqytrbnvVTAzM0OLFi3w5MmTGt2rvLwc//33H+zs7L64TkLI/6EWXx1LSkqCg4MDvvnmG0RERFDofSEvLy9EREQgICCAe8xZVlaGAwcOIC8vDzweD9ra2lxrbMqUKfD398fNmzfBGAOfz8fp06e5tTabNGmC5ORk7vo8Hg89evTA7du3a1WfsbEx2rVrh+3bt6O8vBz379/H7t274eHhAQBwc3PD2rVrkZOTg7S0NGzbto07t0uXLtDW1oafnx+Ki4shFAqRkJCA2NjYKu8VExMDCwuLSq1GQsiXo+CrQydPnoSTkxMWLVpE/Xm1ZGFhge7du4PP52P48OHc60FBQbCwsIC2tjb8/f0RHBwMAOjcuTMCAgIwa9Ys6OnpwdLSEvv27ePOW7RoEVatWgVdXV1uJOj48eMRHh5e6xpXr16NV69eoVu3bnB1dcWKFSvQv39/AMCyZctgbm6OFi1aYMCAARg3bhx3npKSEsLCwnD37l20aNECjRs3xuTJk7kVYz504MABTJs2rdZ1EkLeoZVb6oBIJMLy5cuxb98+HD9+HPb29pIuiVRDIBDA3t4e8+bNQ5s2bWp1DQUFBdja2tbZP24yMzPh6OiIO3fuQE1NrU7uQYi8oD4+Mavoz8vPz6f+PCl1/fp1xMbGIjU1FU+ePEFcXBy2bdsGCwuLWl9TR0enTlv0RkZGePDgQZ1dnxB5QsEnRhXrbQ4cOBCbNm2iR5tSatWqVbhw4QKEQiH32tcs5KyoqAhjY2NxlEYIqQfUxycmJ0+e5Obnbdu2jUJPiq1cuZL7vZKSEszNzTFixAj88ccfH62W8jkVC1VLYpcGQkjtUPB9JZFIhKVLl2LOnDk0P0/KMcYQHByMoUOHonXr1gDerZ+ZkpICgUCA5s2bw9TUtMbhV5vdGQghkkePOr9CXl4ePD09kZeXR/15Uu7p06eYPn06MjMz8c8//6BVq1Zo2rQpSkpKALyblD5lyhQYGhpCQ0NDqvfjI4R8HWrx1dKDBw/QpUsXWFhY4OLFixR6UkogEGDt2rVwcHBA//79ERsbiy5dukBLSwuurq7Q0NCAkpISWrZsiRYtWgAANDU10bJlS9ja2sLExAT6+vrQ0dGBvr4+TExMYGtri5YtW1LoESKjqMVXCydPnsTUqVOxbt06erQpxaKjozF16lQ0a9YMsbGxXLCVl5fDy8sLr1+/xuPHjzFo0CDMnDnzo/N5PB4NWiGkAaJ5fF+A5ufJhry8PPz6668ICQnBpk2bMGbMGO4RZVlZGdzd3cHn8xESEgJ1dXXuUSZt7kqIfKAWXw1Rf570Y4whJCQEc+fOxaBBg5CYmAh9fX3u+6Wlpfjhhx8AvGu1Vyw2TYFHiHyh4KuBBw8ewMXFBf3798emTZugoqIi6ZLIB1JTUzFr1iw8fvwYBw8eRO/evSt9v7i4GK6urmjUqBEOHjxIf4aEyDEa3PIZFfPzFi5ciO3bt9MPTCkjFAqxZcsWdOjQAR07dsTdu3c/Cj0+n4+hQ4dCX18fhw8fpj9DQuQctfg+oaI/b+/evTh16hS6dOki6ZLIB+7cuYOpU6dCU1MT165dq3KdzYKCAgwZMgQtW7bEX3/9xe3iQAiRXxR8VXi/Py8uLo7686QMn8/H8uXLsX//fvz++++YMGFClf10ubm5GDRoENq1a4cdO3Z88aoshJCGiX4SfKBifp65uTntnyeFzpw5AxsbG6SnpyMhIQETJ06sMvSys7Ph7OyMzp07w9/fn0KPEMKhFt97QkNDMWXKFPj5+WHChAmSLoe8JyMjAz/++CNiYmLg7++PgQMHfvLYrKws9O/fH87Ozli/fj2N2iSEVEL/DMa7/rxly5Zh1qxZOHXqFIWeFBGJRAgICEC7du1gYWGBhISEakMvIyMDTk5OGDp0KIUeIaRKDbLFJxAI8PbtWxQXF0MoFEJJSQnq6uowMDD4aNeEvLw8jBs3Djk5OYiNjaWVOqTIgwcPMHXqVJSVleHChQuws7Or9viXL1+iX79+8PDwwJIlS+qpSkKIrGlQwcfn86tdXDg9Pb3S4sIPHz6Ei4sL+vXrh7///puGuUuJkpISrF27Fv/v//0/LF++HNOnT//saMyUlBT069cPU6ZMwYIFC+qpUkKILGowwZeVlYW0tDSIRKIqv18Rgrm5ucjPz8fbt28xduxY+Pn5YeLEifVZKqlGZGQkfHx8YG1tjbt378LU1PSz5yQnJ6Nv37748ccf8eOPP9Z9kYQQmSbTfXzW1taIjIz8bOi5ubkhLi6O+1okEqFRo0Y4ffo0hZ6UePv2LSZOnIhx48bBz88PISEhNQq9x48fw8nJCQsWLKDQI4TUiEwHX2JiIuzt7asNPQA4evQoOnfuDADYuXMnlixZAh6PBx6PBz6fX1/lkipUbA5rbW2NRo0aITExES4uLjU6NykpCX369MGyZcswffr0ui2UENJgyPyjzoyMjGpDrzoikQgZGRlo2bKlmKsiNVGxOezr168RGhoKBweHGp97//59DBw4EOvXr4enp2cdVkkIaWhkOvgsLCywYMEC3LlzB8+ePYOKigoiIyNhbGyM5cuXo23btgCAYcOGYfHixRAKhdi7dy8YY4iMjISpqSkOHz4MgUDw0WhPUncEAgE2btyIDRs2YP78+fjpp5++6PO/ffs2Bg8ejC1btmD06NF1WCkhpCGS6UedQqGQ+/2VK1cwYMAAXL58Gb1798a6des+Or579+6YMGECBgwYgKtXr+LQoUMA3vUvkfoRHR2NTp06ITIyErGxsZg/f/4Xhd7NmzcxaNAg7Nixg0KPEFIrMh18jDFutGb79u3Rs2dPKCkpYfDgwXjy5EmNr1FcXFyXZRIA+fn5mDVrFlxdXbFo0SKcOXOG2xG9pq5du4Zhw4Zhz549cHV1raNKCSENnUwH3/sMDAy436upqaG0tBTl5eU1Ovf9liMRvxMnTqBt27YoKSlBYmIixo4d+8Urqly+fBmurq4IDg7GkCFD6qhSQog8kOk+vtqo6gcubVVTN1JTUzF79mw8fPiwys1ha+r8+fPw9PTEsWPH4OTkJN4iCSFyR6ZbfAoKCl/cctDX10d6ejo3ElRBQQHq6up1UZ7cEgqF2Lp1Kzp06IAOHTrg3r17tQ69U6dOwdPTEydOnKDQI4SIhUy3+GrTUnN2dsaZM2fQr18/mJiY4ODBg5Uek5Kvc/fuXUydOhXq6uqf3By2pk6cOIFp06YhLCzsi6Y6EEJIdRTY+wtayqCnT58iNze31ufr6urSPD4x4PP5WLFiBfbt24e1a9diwoQJX7UH3pEjRzB37lyEh4ejY8eOYqyUECLvZPpRJwAYGxvX+gesoqIi7cYgBmfPnoWtrS1evnyJ+Ph4TJo06atCLygoCD/99BMuXLhAoUcIETuZb/EBn1+guiqKioowNTWFoaFhHVbWsL1+/Ro//vgjbt68iR07dlS7T15N7d69G0uXLsWFCxe4BQgIIUScZL7FBwCGhoYwNTWtcSuDQu/riEQi/PXXX7C1tUXz5s0/uzlsTf35559YsWIFIiMjKfQIIXVGpge3vM/Q0BAaGhrcfnwlJSVQVVXlvl8x+vP9/fjIl3vw4AF8fHxQWlpao81ha2rz5s3YsmULoqKivnhiOyGEfIkG8ajzQwKBADNnzsTgwYNhY2NT7Q7spGbe3xx22bJlmDFjhtjmP/r5+SEgIACXLl1C8+bNxXJNQgj5lAbT4nsfj8fD3r174eTkBEtLS0mXI/OioqLg4+MDKyurGm8OWxOMMaxcuRIHDx5EVFQUmjVrJpbrEkJIdRpk8OXn50MkEuGbb76RdCkyLTs7G/PmzcP58+exdetWsa6PyRjD4sWLERoaiqioKDRp0kRs1yaEkOo0iMEtH0pLS6OpCl+BMYaDBw/C2toaGhoaSExMFHvozZs3D6dPn8bly5cp9Agh9apBtvhSU1MhEolgZGQk6VJkTnJyMqZPn46MjAycPHlS7CumiEQizJ07F9HR0bh06RL09fXFen1CCPmcBtnie/z4MRQVFaGhoSHpUmSGQCCAn58funTpgn79+iEuLq5OQm/atGm4desWIiIiKPQIIRLRIFt8jx8/hpaWlqTLkBk3b97E1KlTYWxsjJiYmDrpGxUKhZg0aRKePXuGc+fO0Z8PIURiGmTwPXv2jFoTNZCfnw9fX1/8/fff2LhxY632yauJ8vJyeHl5ITMzE+Hh4TSHkhAiUQ3yUWdqaioNmPiMEydOwNraGsXFxUhMTIS7u3udhF5ZWRnGjBmDnJwchIWFUegRQiSuQbb4MjMz0bp1a0mXIZXS0tIwe/ZsPHjwAMHBwXB0dKyze5WWluKHH36AgoICTp48WWklHUIIkZQG2eLLzs6mOXwfEAqF2LZtGzp06AA7Ozvcu3evTkOvuLgYLi4uUFVVxbFjxyj0CCFSo8G1+Comr5uZmUm6FKlx7949TJ06FWpqarh69epXbQ5bE3w+H8OHD4exsTH2798PZeUG978ZIUSGNbgWX2pqKtTU1GjyOoCioiIsWLAA/fv3x9SpU3H58uU6D72CggIMGjQIzZs3R2BgIIUeIUTqNLjgS0tLg5KSktwPbjl37hxsbGyQmpoqls1hayIvLw8DBw6ElZUVdu/eLbZFrAkhRJwa3D/HK1Ztkdfge/36NX766SdER0fjzz//xHfffVcv983OzsbAgQPRrVs3bNmypU5GiBJCiDg0yBZfSUmJ3AUfYwy7d++Gra0tTE1NER8fX2+hl5WVhb59+8LJyYlCjxAi9Rpciy85ORkA5GplkIcPH8LHxwfFxcU4f/482rdvX2/3zsjIgLOzM1xcXLBy5UoKPUKI1GtwLb5nz55BT09PLn4Al5aWYvny5ejZsydGjRqFGzdu1GvovXz5Ek5OThg9ejRWrVolF585IUT2NbgWX1pamlzsynDlyhX4+PigTZs2Yt0ctqZevHiBvn37YurUqZg/f3693psQQr5Ggwu+jIyMOp2YLWnZ2dmYP38+zp07J/bNYWsqOTkZ/fr1w9y5c/Hjjz/W+/0JIeRrNKhHnXl5eWCMoVmzZpIuReze3xxWXV1d7JvD1tTjx4/h5OSE+fPnU+gRQmRSg2rxpaWlQUtLq8FNXk9OTsaMGTOQnp5eJ5vD1lRSUhL69++PlStXYuLEiRKpgRBCvlaDavGlpqZCXV29wUxlEAgEWLduHbp06YI+ffrg1q1bEgu9+/fvw9nZGX5+fhR6hBCZ1uBafA1l1ZaYmBhMmTKlTjeHranbt29j8ODB2Lp1K9zc3CRWByGEiEODa/GJRCKZHtWZn5+POXPmYMSIEZg/fz7Onj0r0dC7efMmBg0aBH9/fwo9QkiD0KCCLy0tDWVlZTLb4jt58iSsra3B5/ORmJgIDw8Pic6Nu3btGoYNG4Y9e/bAxcVFYnUQQog4NahHnampqSgsLJS54KvPzWFrKjIyEm5ubggODsaAAQMkXQ4hhIhNg2rxvXjxAiUlJdDT05N0KTVSsTls+/bt62Vz2Jo6f/483NzccPToUQo9QkiD02BafIwxpKamwtDQsM633xGH+/fvY8qUKVBVVcXVq1dhZWUl6ZIAAKdPn8aECRNw4sQJ9OjRQ9LlEEKI2El/QtRQfn4+AEj9HL6KzWGdnZ0xZcoUREZGSk3onThxAhMnTsSpU6co9AghDVaDCb7U1FQYGBhIdf/eh5vDTp48WWpap0ePHsX06dNx5swZdOnSRdLlEEJInWkwjzrT0tKgra0tlVMZMjMz8dNPP+Hff//Fjh076m2fvJoKDg7G/PnzceHCBdja2kq6HEIIqVPS0dwQg9TUVKipqUlVi69ic1gbGxs0a9YMCQkJUhd6e/bswcKFC3Hx4kUKPUKIXGhQLT5lZWWpCb5Hjx7Bx8cHRUVF9b45bE3t2LEDa9euxeXLl/Htt99KuhxCCKkXDarFxxiTePCVlpZixYoV6NGjB0aOHFnvm8PW1ObNm7Fu3TpERUVR6BFC5EqDavFJetWWis1hW7dujTt37sDMzExitVTHz88Pf/31F6KiotC8eXNJl0MIIfWqwQRfamoqysvLJRJ8FZvDnj17Ftu2bZPIPnk1tXLlShw4cABRUVEwMTGRdDmEEFLvGsSjzorJ67m5ufUafIwxHDp0CNbW1lBTU5PY5rA1wRjD4sWLceTIEQo9QohcaxAtvry8PCgoKCA3NxcGBgb1cs9nz55h+vTpSE9Px4kTJ9C1a9d6uW9tMMYwb948RERE4PLlyzA0NJR0SYQQIjENosWXlpYGExMT6OnpQVm5brNcIBBg/fr1sLe35zaHlfbQmzt3LqKionDp0iUKPUKI3GsQLb6KVVtUVFTq9D4xMTGYOnUqjIyMcPPmTbRs2bJO7/e1RCIRpk+fjvj4eEREREBHR0fSJRFCiMQ1iOCrWLVFQ0OjTq5fUFAAX19fHDt2DBs2bIC7u7tE98mrCaFQiMmTJyM5ORnnzp2DlpaWpEsihBCp0CAedaampkJdXb1OBracPHkSbdu2BZ/PR0JCgsQ3h62J8vJyeHl5ITU1FeHh4RR6hBDyngbT4uPxeGINvpcvX2L27NlITExEUFAQnJycxHbtuiQQCODu7o7CwkKEhYVBXV1d0iURQohUkekW388//ww7OzuEhYXh3r17ePbsGUpKSr7qmkKhENu3b0f79u1ha2uLe/fuyUzolZaWYtSoUSgrK8PJkycp9AghpAoy3eLT1tZGUlISysvL8ebNGyQnJ4PP50NNTa1W17t//z6mTp0KFRUVXLlyRWr2yauJ4uJijBw5Eo0aNcKBAwfqfKAPIYTIKplu8Y0fP56bvqCoqIhJkybVah5fUVERFi5cCGdnZ0yaNEmqNoetCT6fj2HDhkFfXx+HDh2i0COEkGrIdPBZWFigVatWAABVVVVMmjTpi69x/vx52NraIiUlBffv38eUKVOkZnPYmigoKMDgwYNhZmaGwMDAOp/HSAghsk7mf0r+8MMPuH//Pho1aoSmTZvW+Lz3N4f9888/MWjQoDqssm7k5eVh0KBBsLW1xY4dO2QqsAkhRFJk/iflzz//jIMHDyInJ6dGu68zxrBnzx7Y2tpym8PKYuhlZ2fD2dkZnTt3hr+/P4UeIYTUkEy2+AQCAd6+fYvi4mIIhUJ06NABkyZN+uz8uorNYfl8Ps6dOyeV++TVxJs3b9C/f384Oztj3bp1Uj+vkBBCpIkCY4xJuoia4vP5yMjIQF5eHoB3rbcKpaWlUFNTg46ODoyNjaGpqVnpe7///ju2bduGpUuXYubMmVBSUqr3+sXh9evX6NevH1xcXLBy5UoKPUII+UISez7Wo0cP3Llzp8bHZ2Vl4fHjx8jNzQVjDB/mtaqqKhhjyM3NxePHj5GVlQUAuHr1Ktq3b4/bt2/jzp07mDNnjlhC7/nz51BQUEB5eflnj/3nn38wZsyYr77ny5cv4ejoiNGjR2PVqlUUeoQQUgufDb7Q0FAYGxvX6Ad8VSwsLBAREVHptbCwMGhpaaFDhw41ukZWVhbS0tIgEolqdLxIJEJaWhr+/PNPjB07FqtXr8bJkycltiP68OHDkZCQgPv379f6Gi9evICTkxMmTpyIJUuWiLE6QgiRL58NvqCgIHh4eIh1mLy/vz/GjRv3ye+/H7J8Pv+LQq+CSCSCvb09bt26hZEjR0q8dTR27Fjs2rWrVuc+e/YMjo6OmDlzJubPny/mygghRM6wamRnZzNVVVV29+5ddvr0aWZlZcUaNWrETExM2Pr167njwsLCmJ2dHdPR0WHdunVj9+7dY4wx5unpyRQUFJiamhrT1NRkfn5+rLS0lKmpqbHU1FTu/GXLlrHvv/+eeXh4MC0tLRYQEMByc3PZxIkTmaGhITM0NGQTJ05kN2/eZHFxcezEiROsY8eOTFNTk+no6LD+/fuzuLg4FhcXx8aMGcOaNGnCNDU1WZs2bdihQ4cq3WfUqFHMw8ODNWrUiNnY2LBHjx6xNWvWMENDQ2ZqasrOnTvHHe/o6MgWLlzI7O3tmba2Nhs+fDh7+/YtY4yxZ8+eMQBMIBAwxhhXr7GxMTMxMWG+vr6svLycu9a1a9eYhYVFdR93lR4/fszMzMzYn3/++cXnEkII+Vi1wefv78/s7OwYY4wZGxuzK1euMMbeBeKtW7cYY4zdunWLGRoasujoaFZeXs727dvHzM3NWUlJCWOMMXNzc3bhwgXumgkJCUxDQ6PSfZYtW8aUlZXZiRMnmFAoZEVFRWzEiBFs8uTJ7Nq1a+z8+fOsbdu2bNGiRSwuLo4NGDCATZ8+ncXExLDr16+zv/76iwu+3377jUVERLDo6Gj2448/MgMDA5afn8/dR1VVlZ09e5YJBAI2btw4ZmFhwVatWsXKysrYrl27KoWTo6MjMzExYfHx8aywsJCNHDmSeXh4MMY+Dr4RI0awqVOnssLCQvb69Wtmb2/P/P39uWu9ffuWAWB5eXk1/sNJSkpizZo1Y7t3767xOYQQQqpX7aPOwMBAeHt7AwB4PB6SkpKQn58PPT09dOzYEQAQEBAAHx8fODg4QElJCd7e3lBVVUV0dHSV18zNza1ym5xu3brBxcUFioqKyM/Px5kzZ/Drr79CXV0d+vr6cHd3x/nz5wEAysrKyMjIQFZWFlRVVStNSxg8eDB0dXWhrKwMT09PlJWVISYmhvt+r169MHDgQCgrK+OHH35AVlYWFi5cCB6PhzFjxuD58+fIzc3ljh83bhxsbGygqamJlStX4ujRoxAKhZVqf/36Nc6cOYPNmzdDU1MTRkZG+Omnn3D48GHumIr3/P61q3P//n3069cPv//+OyZOnFijcwghhHxetR13sbGxCAkJAQAcP34cq1atwsKFC9GuXTv8/vvv6NatG1JSUrB//35s27aNO6+srAzp6elVXlNPTw8FBQUfvf7+wJOUlBQIBALY2dlxozcZY9y2Q3PmzIG/vz+8vb2hra0NDw8PjBgxAgAQHByMkydPIisrCwoKCuDz+Xj16hV37fe3LlJXV0fjxo25UZ4VuxkUFhZCV1f3o7rMzc0hEAjw5s2bSrVX1Pv+yjEikajSuRXvueK61bl9+zYGDx6MrVu3ws3N7bPHE0IIqblqg2/AgAFcUNjb2yM0NBQCgQDbt2+Hm5sbUlNTYWZmBl9fX/j6+lZ5jQ8HlXz77bdgjOHly5do1qxZlceZmZlBVVUVMTEx4PP5H12zcePGWLx4MQDg7t27mDFjBjp27Ig3b95g//792LFjB7755hsoKiqiT58+H7XQvkRqair3+xcvXoDH46Fx48aVXq+o982bN58cBPTgwQNYWFhAW1u72vvFxMRg2LBh2LlzJ1xcXGpdNyGEkKpV+6iz4jFnWVkZDhw4gLy8PPB4PGhra3OtpClTpsDf3x83b94EYwx8Ph+nT5/mWjhNmjRBcnIyd00ejwdnZ2dERUV98r5NmzbFgAED4Ofnh8LCQm56wq1btwAAEREReP36NYB3jxAVFBSgqKgIPp8PJSUl6OrqQigUIiAgAHw+/6uW8woODkZSUhKKioqwdOlSjBo16qN5gBX1/vLLL8jPz4dIJMLTp08rvceoqKjPLo12/fp1DB06FHv27KHQI4SQOlJtIgwfPpz7fVBQENdi8ff3R3BwMACgc+fOCAgIwKxZs6CnpwdLS0vs27ePO2/RokVYtWoVdHV1sWHDBgCAj48PgoKCqi0sMDAQIpEIbm5u6NOnD+bPn889YkxMTMT48ePRq1cv/Pzzz/jll1/QrFkzdOvWDd27d8f333+PoUOHQkVFBU2aNIGqqmqtPhzgXR/f+PHjYWxsjJKSEmzduvWT9ZaVlaFt27bQ09PDqFGjKj1iPXToEHx8fD55n8jISLi6uiI4OBhDhgypdb2EEEKqJ7Ely3r27Ilt27ZVO4ldIBAgPj7+o1VavoSCggJsbW3B4/G++FwnJyd4enpi8uTJtb4/8G7CflBQEI4ePVrl9y9cuAAPDw8cPXpUZnZ7J4QQWSWxRaqvXbv22WN4PB50dHRqPBKyKjo6OrUKPXEaNmwYhg0bVuX3wsPDMX78eJw4cQI9evSo58oIIUT+SP1eNsbGxrXuo1NUVISxsbGYKxKfkydPYsKECQgLC6PQI4SQeiITuzN86VqdwLvQMzU1haGhYR1WVntHjx7FnDlzEB4ezs2JJIQQUvekvsUHAIaGhjA1Na1xy0/aQy84OBg//vgjLly4QKFHCCH1TCZafBWq24+vYh5gVfvxSZM9e/Zg6dKlOH/+PNq2bSvpcgghRO7IVPBVqNiBff/+/TA1NUWzZs3Qpk0bGBgYSHwgS3V27NiBtWvX4uLFi/j2228lXQ4hhMglmQw+4F1rT0VFBZ06dcKGDRvQs2dPSZdUrS1btmDz5s24dOkSWrRoIelyCCFEbklsOsPXKioqAo/HQ1ZWVqX1N6XRunXrsGvXLkRFRaF58+aSLocQQuSazAZfbm4udHV1kZmZKdXBt3LlShw4cABRUVGV1iYlhBAiGTIxqrMqubm50NHRQXl5eZXbHEkaYwyLFy/GkSNHKPQIIUSKyHSLT0NDA0ZGRh/tACFpjDHMnz8fFy5cwOXLl6V2WgUhhMgjmQ4+VVVVqXvMyRjD3LlzcePGDVy6dAn6+vqSLokQQsh7ZDr4lJWVYWBgIOlSOCKRCNOnT0d8fDwiIiKgo6Mj6ZIIIYR8QKaDT1FRUWpafEKhEJMnT0ZycjLOnTsnlf2OhBBCZDz4RCKRVARfeXk5vL29kZGRgfDwcKldNYYQQoiMB195ebnEg08gEMDd3R2FhYU4deoU1NXVJVoPIYSQ6sl08JWVlUk0+EpLS+Hm5gbg3RZDX7PTOyGEkPoh0/P4ioqKYGRkJJH7FxcXw9XVFTweD8eOHaPQI4QQGSHTwVdQUCCRFh+fz8fw4cOhq6uLw4cPQ0VFpd5rIIQQUjsyHXy5ubn1HnwFBQUYPHgwTE1NERQUBGVlmX1aTAghcklmgy8nJwclJSXQ09Ort3vm5eVh4MCBaNOmDXbv3g0lJaV6uzchhBDxkOngMzAwqPGu7F8rOzsbzs7O6NSpE/z9/evtvoQQQsRLJn96M8aQl5cHY2Pjernfmzdv0K9fPzg6OmLr1q1StzYoIYSQmpPJ4CsqKoKSkhKaNm1a5/d6/fo1nJycMGTIEKxfv55CjxBCZJxMBl9ubi7U1dXrfCrDy5cv4ejoiNGjR2PVqlUUeoQQ0gDIbPDV9c4ML168gJOTEyZMmIAlS5bU2X0IIYTUL5kNPiUlpToLvmfPnsHR0REzZ87EggUL6uQehBBCJEMmJ6Hl5uYCQJ0E35MnT+Ds7IyFCxdi+vTpYr8+IYQQyZLZ4KuLnRkePHiA/v37Y8WKFZg0aZJYr00IIUQ6yGzwiXuB6vj4eAwcOBB+fn4YN26c2K5LCCFEushs8JWWloot+O7cuYNBgwZhy5YtGD16tFiuSQghRDrJZPBlZ2ejpKQEjRs3/uprxcTEYNiwYfD394erq6sYqiOEECLNZDL4MjIyoKGh8dVrZV6/fh2urq7Yu3cvhgwZIqbqCCGESDOZnM6QmZn51YtTR0ZGwtXVFcHBwRR6hBAiR2Syxff27VsYGBjU+vyIiAi4u7vjyJEj6NOnjxgrI4QQIu1kssX3NfvwhYeHw93dHSEhIRR6hBAih2Qy+AoKCmq1QPXJkycxYcIEhIWFoWfPnnVQGSGEEGknU8E3ZcoUdO7cGdnZ2bhz5w5Wr16NkpKSGp177NgxTJs2DWfOnIGDg0MdV0oIIURaKTDGmKSLqClzc3O8ePGi0mvnz59H//79qz0vODgY8+fPx9mzZ9GuXbu6LJEQQoiUk6kW3+rVqyt9bWlpCWdn52rP2bNnDxYuXIiIiAgKPUIIIbLV4isvL4eGhgYEAgEUFBTw8OFDtGrV6pPH+/v7Y82aNYiIiKj2OEIIIfJDplp8ysrKcHFxAQCMHj262jDbsmUL/Pz8EBkZSaFHCCGEI1MtPgBIS0uDs7Mzbt26BU1NzSqPWbduHXbt2oWLFy/C3Ny8niskhBAizWQm+AQCAd6+fYvi4mIIhUIoKSlBXV0dBgYG4PF43HErV67EgQMHcPHiRTRr1kyCFRNCCJFGUh98fD4fGRkZyMvLAwC8X66CggIAQEdHB02aNIGfnx9CQkJw8eJFGBsbS6ReQggh0k2qlyzLyspCWloaRCJRld+vCMHc3Fy8ffsW+fn5iIyMhKGhYX2WSQghRIZIzeCWHj164M6dOwCANWvWwNPTs9rQ+5CSkhK8vb3rssSPlJaWok2bNsjMzKzX+xJCCKm9aoNv6dKlH70WGhoKY2NjlJeX1+qGFhYWiIiIqPRaWFgYtLS00KFDBwDA3Llz8csvv9Q49CowxpCWlgY+n1+r2p4/fw4FBYUavzdVVVVMnDgRfn5+tbofIYSQ+ldt8AUFBeHDLsCgoCB4eHhAWVl8T0n9/f0xbtw47uuMjIwvDr0KIpEIGRkZ4irts9zd3bF//36UlpbW2z0JIYTUXrXBl52djatXr3Jf5+Tk4NSpU/Dy8kJ4eDjatm0LLS0tNGvWDBs2bOCOO3XqFNq3bw9dXV10794d9+/fBwCMGzcOL168wLBhw9CoUSOsW7cOZWVluHTpEhwdHQG8G725bt06LFmyBACQnp6Ozp07459//sGQIUPQp08f/P3330hMTMSYMWPg5ORUqcUVFhaG77//HjNnzoSOjg7atGmDixcvct//sMW5fPlyeHp6AgB69+4NANDV1UWjRo1w48YNAO9Wf7GysoKenh4GDhyIlJQU7nxTU1Po6ekhOjr6Sz53QgghElJt8Lm5uSEwMJD7+ujRo2jTpg3s7OwwadIk7Ny5EwUFBUhISEDfvn0BALdv38bEiROxc+dOvH37Fj4+Phg+fDhKS0sRFBSE5s2bIywsDIWFhZg/fz6ePHkCRUVFmJqaAni3115VEhISEBISgrVr12LTpk3Ys2cP/vzzTxw9ehQRERG4detWpWONjIzw5s0brFixAiNHjkR2dvZnP4wrV64AeDdYprCwEN26dcPJkyexZs0ahISEICsrC7169cLYsWMrnWdlZYV79+599vqEEEIkr9rg8/b2xrFjx1BcXAwACAwM5AaQ8Hg8JCUlIT8/H3p6eujYsSMAICAgAD4+PnBwcOAGnKiqqn6yRZSbmwstLS3u6+Li4o8erwLA5MmToaqqiq5du0JdXR0DBw6Evr4+jIyM0L59ezx69Ig7Vk9PD+PGjQOPx8Po0aPRunVrnD59+gs/mnd27tyJRYsWwcrKCsrKyvj1119x9+7dSq0+LS0t5Obm1ur6hBBC6le1wdezZ08YGhoiNDQUycnJiI2Nhbu7OwDg+PHjCA8Ph7m5ORwdHbnHgikpKdi4cSN0dXW5X6mpqUhPT6/yHnp6eigoKOC+FgqFVR6nr6/P/V5VVbXS12pqaigqKuK+NjIyqtRHaG5u/sn7f05KSgrmzp3LvRd9fX0wxvDy5UvumIKCAujq6tbq+oQQQurXZ6czeHl5ITAwEEFBQRgwYAC387m9vT1CQ0ORmZkJFxcXuLm5AQDMzMzg6+uL3Nxc7ldRURH3eLBi0nmFb7/9tlKQKCkpffWbyszMhKLi/721Fy9ewMTEBACgqalZKSTfHwjzYW0V72fnzp2V3k9xcTG6d+/OHfPgwQPY2dl9dd2EEELqXo2CLyIiAgEBAdxjzrKyMhw4cAB5eXng8XjQ1tbmAmvKlCnw9/fHzZs3wRgDn8/H6dOnuVZdkyZNkJyczF2fx+PB2dkZUVFRAAB1dfUqA+hL5OTk4MCBAxAIBDh27BgePHiAwYMHAwDat2+Pw4cPQyAQIC4uDn///Td3nqGhIRQVFSvVN23aNKxduxaJiYkAgLy8PBw7doz7/suXL5GdnY2uXbt+Vc2EEELqx2eDz8LCAt27dwefz8fw4cO514OCgmBhYQFtbW34+/sjODgYANC5c2cEBARg1qxZ0NPTg6WlJfbt28edt2jRIqxatQq6urrcSFAfHx8EBQUBAAwMDL76TdnY2ODVq1do3LgxfH198ffff3PXXblyJZ4+fQo9PT0sW7aMe3QLABoaGvD19UWPHj2gq6uL6OhouLq6YsGCBRgzZgy0tbVhY2ODM2fOcOccPHiQ68ckhBAi/aRmrc6ePXti27Zt6NChA54+fVrrwSJhYWE4deoU4uLixFtgFUpLS2FnZ4crV67AyMiozu9HCCHk60nNWp3Xrl3jfm9sbIz8/PxaTWJXUFCAioqKOEv7JFVVVTx8+LBe7kUIIUQ8pGatzvdpamrC1NS00gCVmlBUVIS+vv4Xn0cIIUR+SM2jzqp8bneG91VMgqedGQghhFRHqoMPqPl+fMbGxp/ckZ0QQgipIPXBV6GmO7ATQggh1ZGZ4COEEELEgUaBEEIIkSsUfIQQQuQKBR8hhBC5QsFHCCFErlDwEUIIkSsUfIQQQuQKBR8hhBC5QsFHCCFErlDwEUIIkSsUfIQQQuQKBR8hhBC5QsFHCCFErlDwEUIIkSsUfIQQQuQKBR8hhBC5QsFHCCFErlDwEUIIkSsUfIQQQuQKBR8hhBC5QsFHCCFErlDwEUIIkSv/HypzY+cArps5AAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "build_graph(best_model_set)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "noted-young",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((<vflow.vset.Vset at 0x7fec3fc50ee0>,\n",
+       "  ('init',),\n",
+       "  (<vflow.vset.Vset at 0x7fec3fbffb20>,\n",
+       "   (<vflow.vset.Vset at 0x7fec3fbffa90>, ('init',)))),\n",
+       " <vflow.vset.Vset at 0x7fec3fbffa90>,\n",
+       " ('init',))"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_trainval = best_impute_set.fit(X_trainval).transform(X_trainval)\n",
+    "best_impute_set.__prev__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "rough-washington",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<vflow.vset.Vset at 0x7fec3f117790>"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "best_model_set.fit(X_trainval, y_trainval)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "id": "coordinated-contact",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/james/school/yugroup/projects/pcs_inference/pcs_pipeline/veridical-flow/vflow/pipeline.py:143: UserWarning: This figure includes Axes that are not compatible with tight_layout, so results might be incorrect.\n",
+      "  plt.tight_layout()\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<networkx.classes.digraph.DiGraph at 0x7fec3f337d30>"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAb4AAAEuCAYAAADx63eqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABZG0lEQVR4nO3dd1yVdf/H8RdLQAQOS1AgcOZIcW9FvV25RTNz4czRsPK2UstRZprVXa5A1BS0TFMjBHOkIpozd3q7RRBBBJEh4wDX7w9/XDfIEBCFA5/n4+Hj4bnONb7nFL75bj1FURSEEEKICkK/tAsghBBCvEgSfEIIISoUCT4hhBAVigSfEEKICkWCTwghRIUiwSeEEKJCkeATQghRoUjwCSGEqFAk+IQQQlQoEnxCCCEqFAk+IYQQFYoEnxBCiApFgk8IIUSFIsEnhBCiQpHgE0IIUaFI8AkhhKhQJPiEEEJUKBJ8QgghKhQJPiGEEBWKBJ8QQogKRYJPCCFEhSLBJ4QQokIxLO0C6CKtVktMTAzJyclkZGRgYGCAqakpNjY2GBkZlXbxhBBCFEBPURSltAuhK5KSkoiMjOThw4cAZP/q9PT0ALC0tMTBwQEzM7NSKaMQQoiCSfAVUnR0NOHh4WRmZj71XH19fZycnLCzs3sBJRNCCFEU0sf3FO3bt2ffvn2FDj2AzMxMwsPDiY6OLvRzDhw4gJOTU6HOnTdvHiNHjgQgKiqK+vXrk5qaWuhnCSFERaZzwdezZ0/mzJmT67i/vz8ODg6kp6cX676urq7s3bs3x7GAgAAqV66MlZVVoUMvS1b4JSUlFas8hWVvb0+XLl1YtWrVc32OEEKUFzoXfGPGjMHPz48nW2j9/PwYMWIEhoYlN17Hy8uLV199tcihlyUzM5PIyMgSK09+RowYgbe393N/jhBClAc6F3wDBw4kNjaWkJAQ9diDBw/YsWMHo0ePJigoiAYNGmBubo6joyNff/21et6OHTto0qQJGo2Gdu3ace7cOQBGjRrF7du36devH1WqVOGrr74iLS2Nffv2Ub9+ffV6b29vPvroIz799FM6derE66+/TmhoKD/++CPdu3enT58+HD16VD0/OjqacePGYW1tTe3atfHx8VHfS05OZsyYMVhZWdGgQQNOnDiR43NGREQwePBg7OzsqFGjBkuXLs33O2ndujU3btwgNDS0+F+sEEJUEDoXfKampgwdOhRfX1/12ObNm6lXrx5ubm6MHz8eb29vEhISuHDhAl27dgXg1KlTjBs3Dm9vb2JiYpg0aRL9+/cnNTUVPz8/XnrpJQICAkhMTOTDDz/k6tWr6OnpYW9vn+P5ISEh9O7dm3379vHyyy/zzjvvkJmZyc6dO5kwYQILFy5Uz509ezZVq1bl1KlT/Prrr8yaNYs///wTgPnz53P9+nWuX7/Orl27WL9+vXpdZmYm/fr1w83NjTt37vDnn3/y3XffsWvXrjy/E0NDQ2rXrs3Zs2dL7HsWQojySueCD8DT05MtW7aQnJwMgK+vL56engAYGRlx8eJF4uPjsbKyolmzZgD4+PgwadIkWrdujYGBAZ6enhgbG+eooWUXFxeHmZlZribVJk2a0LZtWwwNDenWrRsPHjxgzJgxGBoa0qNHDyIiIkhISCAyMpIzZ87wzjvvoCgKTZo0YcKECfj5+QGPw3r27NlYW1vj7OzMu+++qz7jxIkTREdHM2fOHCpVqkTNmjWZOHEimzZtyvc7MTc3Jy4urtjfqRBCVBQ6GXwdOnTAzs4Of39/bty4wYkTJxg+fDgAW7duJSgoCBcXF9zd3Tly5AgAoaGhfPPNN2g0GvVPWFgYEREReT7Dysoqz4EpNjY26t+NjY3RaDQYGBiorwEePXrE/fv3sbCwwMzMjIyMDABcXFy4c+cO8Lgp09nZWb2Xi4uL+vfQ0FAiIiJylHXhwoVERUXl+50kJCSg0Wie+t0JIURFp7Mrt4wePRpfX18uX75Mjx491CbJli1b4u/vj1arZfny5QwdOpSwsDCcnZ2ZPXs2s2fPzvN+WRPQs9SpUwdFUbh37x5Vq1YtcvlsbW2Jj48nKSkJa2trAG7fvo2joyMA1apVIywsjIYNG6rvZXF2dqZGjRpcvXq1UM9KT0/n2rVruLm5FbmcQghR0ehkjQ8eB9/evXvx8fFRmznT0tLYuHEjDx8+xMjICAsLC7U2NnHiRLy8vDh27BiKopCUlERgYCAJCQnA42kBN27cUO9vZGREp06dOHXqVLHK5+DgQOPGjVmxYgV6enqcO3eONWvWMGLECACGDh3Kl19+yYMHDwgPD2fZsmXqta1atcLCwoLFixery6JduHAh1wCYLMePH8fV1TVHrVEIIUTedDb4XF1dadeuHUlJSfTv31897ufnh6urKxYWFnh5ebFhwwYAWrRogY+PD2+//TZWVlbUrl2bdevWqdfNnDmTBQsWoNFo1JGgU6dOJSgoqNhl/OKLL4iIiKBZs2YMGjSI+fPn0717dwDmzp2Li4sLNWrUoEePHowaNUq9zsDAgICAAM6cOUONGjWwtbVlwoQJ6lJpT9q4cSOTJ08udjmFEKIikSXLnqJFixa8//771KtXr1jXazQaatWqVcKl+p979+7h7u7O6dOnMTExeW7PEUKI8kKC7ymSkpK4cuVKsSax6+vrU7duXVmwWgghyhCdbep8UczMzHByckJfv2hfVdZC1RJ6QghRtkjwFYKdnV2Rwk92ZxBCiLJLmjqLIGs/vri4OLRabY5NZ2U/PiGE0A06O4+vNJiZmREXF0f37t0ZPXo0tWrVwtHRkaZNm8oO7EIIoSOkxlcEoaGhNG7cmPj4eIyMjMjIyMDExITY2Fh11RYhhBBlm/TxFdLDhw/p3LmzOuFdq9WiKAoZGRk5FpgWQghRtkmNr5CmTJmCj4+Puu5mdg4ODoSFhZXoXoBCCCGeD6nxFdIXX3yBr68vpqamaj+enp4eRkZGREZG5rvLgxBCiLJFqiiFZG1tTcuWLbG2tmb06NGkpaVx+fJlBg0aRO/evXPt2yeEEKJskhpfEezfv58uXbpw/fp1dZ8/W1tbHBwccu3uIIQQomyS4CuC/fv307VrV65evUqdOnVyzeUTQghR9knwFZKiKOzfv5/OnTtL8AkhhA6T4CukS5cuYWpqiomJCSYmJmg0Ggk+IYTQQRJ8hZTVv5dV2wMk+IQQQgdJ8BVS9uCrW7cu8HjH90qVKpVyyYQQQhSFBF8hZGZmcuDAAanxCSFEOSDBVwgXLlzA2toaJycnCT4hhNBxEnyFsG/fPrp06QIgwSeEEDpOgq8Qsvr3MjMzuX79OrVr1wYk+IQQQhdJ8D1FRkYGBw8epHPnzkRERGBhYYG5uTkgwSeEELpIgu8pzpw5Q7Vq1XBwcMjRzAkyqlMIIXSRBN9TZC1TBuQKPqnxCSGE7pHge4rsA1uuXLkiwSeEEDpOgq8AWq2Ww4cP4+7uDkiNTwghygMJvgL8/fffuLq6YmtrC+QMPkVRSE9Pl+ATQggdI8FXgKxpDPB4dOfNmzfVqQzp6ekYGhrKPnxCCKFjJPgKkD34wsLCsLW1pXLlysDjEZ1S2xNCCN0jwZeP1NRUjhw5Iv17QghRzkjw5eP48eO8/PLLaDQaQIJPCCHKCwm+fGRv5gQJPiGEKC8k+PIhwSeEEOWTBF8eUlJSOHHiBB07dlSPyXJlQghRPkjw5eHIkSM0atRIXYw6PT2d0NBQatasqZ4jNT4hhNBNEnx5yL5MGcCtW7dwcHDAxMREPSbBJ4QQukmCLw9P698DCT4hhNBVEnxPSEpK4syZM7Rv3149JsEnhBDlhwTfEw4fPkzTpk3VFVrgcfDVrVs3x3kSfEIIoZsk+J7wZDMn5F3jk1GdQgihmyT4nrBv3z5149ks0tQphBDlhwRfNvHx8fzzzz+0adNGPZaWlsadO3dwdXXNca4EnxBC6CYJvmxCQkJo1apVjmkLN2/exMnJKVezpgSfEELoJgm+bArbvwcSfEIIoask+LKR4BNCiPJPgu//PXjwgKtXr9KqVascx/MLPhnVKYQQukmC7/8FBwfTtm3bXGEmNT4hhChfJPj+X17NnABXrlyR4BNCiHJEgu//5RV8KSkpREVF4eLikut8CT4hhNBNEnxAdHQ0oaGhNG/ePMfx69ev4+LigqGhYa5rJPiEEEI3SfDxuH+vY8eOuQIuv/49eBx8MrhFCCF0jwQfufffy5LX4tRZ0tLSpMYnhBA6SIKP/Ae2PK3GJ8EnhBC6p8IH3927d4mKisLNzS3XexJ8QghR/lT44Dtw4ACdOnXCwMAg13sSfEIIUf5U+ODLr5nz0aNHxMTE4OzsnOd1EnxCCKGbJPj278+1/x7AtWvXqFmzJvr6eX9FsmSZEELopgodfGFhYcTFxdGwYcNc7xXUzAlS4xNCCF1VoYNv//79dO7cOc9anQSfEEKUTxU++PLq3wMJPiGEKK8k+PIJvvwWp84iwSeEELqpwgbfzZs3SU1NpV69enm+LzU+IYQonyps8GUtU6anp5frvfj4eBISEqhevXq+18uoTiGE0E0VNvgKaua8du0atWvXzncqA0iNTwghdFWFDD5FUZ5pYAtI8AkhhK6qkMF39epV9PX1qVWrVr7vS/AJIUT5VCGDL6u2l1f/HkjwCSFEeVYhg2/fvn15LlOWpbDBJ4NbhBBC91S44FMUhQMHDuTbvweFCz7ZiFYIIXRThQu+ixcvYmZmhouLS57vx8XFkZKSgr29fYH3kaZOIYTQTRUu+AoazQn/q+3l1/+XRYJPCCF0kwTfEwrTzAkSfEIIoasMS7sAL1JmZibBwcEsXbo013uHDx8mODiYM2fOYGlpSVJSEmZmZvneS4JPCCF0U4UKvnPnzmFjY4Ojo2Ou906dOsXcuXPR09PDwMCA1atXExwcTKdOnfK8l4zqFEII3VShmjoLauYcPHgwBgYGaLVadfHqtm3b5nsvGdUphBC6SYLv/1WvXp2XX34ZABMTE7Zv315gsElTpxBC6KYKE3wZGRmEhITQuXPnfM8ZOnQoAF988UW+2xVl3QvAwMCgRMsohBDi+aswwXf69GkcHR0LnJ/3xhtv4O7uzrRp0wq8l9T2hBBCd1WYwS1Z++89SavVEhMTQ3JyMpmZmfz444/cu3cPGxubfMNNgk8IIXRXhQm+/fv3M3HiRPV1UlISkZGRPHz4EHi8lFkWPT09IiIisLS0xMHBIde0BtmEVgghdJeekv1f/HJKq9ViY2PDzZs3sbGxITo6mvDwcDIzM596rb6+Pk5OTtjZ2anHIiMjcXNzIyoq6nkWWwghxHNQIfr4Tp48Sc2aNfMMvXHjxvHf//4332szMzMJDw8nOjpaPVbUps558+YxcuRIAKKioqhfvz6pqanF/DRCCCGeRZkLvp49ezJnzpxcx/39/XFwcCA9Pb3I99y/fz83b95kx44dOULv4MGDmJmZFTiCE/4XfklJScCz9fHZ29vTpUsXVq1aVazrhRBCPJsyF3xjxozBz8+PJ1tg/fz8GDFiBIaGRe+W3LdvHyYmJsTGxuZo3ty6dSu9e/cu1D0yMzOJjIwEnn1wy4gRI/D29i729UIIIYqvzAXfwIEDiY2NJSQkRD324MEDduzYwejRowkKCqJBgwaYm5vj6OjI119/rZ63Y8cOmjRpgkajoV27dpw7d47U1FSCg4OJjo7mzTffpGPHjqxfvx6tVsvJkydp1qyZen1mZibr1q1jwIAB/Otf/+Ljjz9WB7+88847rFq1Cq1Wqwafm5sb27ZtA2DatGk4OztjYWFB8+bNc5T/Sa1bt+bGjRuEhoaW9NcnhBDiKcpc8JmamjJ06FB8fX3VY5s3b6ZevXq4ubkxfvx4vL29SUhI4MKFC+pO6qdOnWLcuHF4e3sTExPDpEmT6N+/PyEhITRp0gRHR0f+85//EBISgqenJ7dv30ZPTy/HvL5NmzZx4MABVq1axc6dOzE3N2fx4sXA4ybYXbt2ERMTQ1paGhkZGYSGhtKnTx8AWrZsyZkzZ4iNjWX48OG89tprpKSk5PkZDQ0NqV27NmfPnn1eX6MQQoh8lLngA/D09GTLli0kJycD4Ovri6enJwBGRkZcvHiR+Ph4rKys1Bqbj48PkyZNonXr1hgYGODp6YmxsTEbN26kS5cuKIqSo/k0ISEh1zSFbdu2MXXqVOzt7alUqRKTJk3izz//JD09nS5dunD58mWuXbuGVqslPj4eDw8PjI2NARg5ciQ2NjYYGhoyffp0UlNTuXz5cr6f0dzcnLi4uJL82oQQQhRCmQy+Dh06YGdnh7+/Pzdu3ODEiRMMHz4ceNwvFxQUhIuLC+7u7hw5cgSA0NBQvvnmGzQajfonLCyMY8eOqbXC7CwsLNTBKlnu3r3LjBkz6Ny5M507d2bIkCEYGBgQGxuLmZkZHTp0wN/fH61WS2xsLCNGjFCv/eabb6hfvz6WlpZoNBoePnzI/fv38/2MCQkJaDSaEvi2hBBCFEWZncA+evRofH19uXz5Mj169FCbJFu2bKmGz/Llyxk6dChhYWE4Ozsze/ZsZs+erd4jOTkZOzs7OnTokGtH9ZdeeglFUbh37x5Vq1YFHo+4nDNnDk2aNMmzTD179mTt2rW4uLigKIq6EkxISAiLFy/mzz//pGHDhujr62NlZZVrgE6W9PR0rl27hpub27N+TUIIIYqoTNb44HHw7d27Fx8fH7WZMy0tjY0bN/Lw4UOMjIywsLBQF4qeOHEiXl5eHDt2DEVRSEpK4ttvv6Vhw4ZUqVKFqlWrEhERod7f0NCQVq1acerUKfXY4MGDWblyJXfv3gUeD6o5cOCA+n6HDh2IiIhg7dq12Nvbo6//+OtLSEjA0NAQOzs70tPT+eyzz4iPj8/3sx0/fhxXV1dcXFxK7PsSQghROGU2+FxdXWnXrh1JSUn0799fPe7n54erqysWFhZ4eXmxYcMGAFq0aIGPjw9vv/02VlZW1K5dmw0bNtCxY0cAZs2axerVq+ncuTN+fn7A46ALCgpS7/3GG2/QqVMn3nrrLTp16sSYMWP4559/1PcrVarEoEGDOH36NM7Ozurxnj178uqrr1K3bl1cXFwwMTHJ8f6TNm7cyOTJk0vmixJCCFEk5XrJsvbt2zN//ny6desGwPXr13MNKBk/fjwzZsx46iR2AI1GQ61atdi+fTvr16/nt99+K3KZ7t27h7u7O6dPn8bExKTI1wshhHg2ZbaP71klJiZy9uxZ2rVrpx5zcHAgPj4+xyT2NWvWFOp++vr6ODg4AM82gb1q1apcunSpWNcKIYR4dmW2qfNZHTp0iObNm1O5cmX1mJmZGU5OTmrfXGFlLVSdNf1BtiUSQgjdVW6Db//+/Xnuv2dnZ1fo8MvMzCQtLQ1HR8ccuzNI8AkhhO6qcMEHj8Ovbt26aDQa9PT0ck11yDqm0Wj4+uuv8ff3z/G+BJ8QQuiuctnH9/DhQy5dukSbNm3yPcfMzIxatWqh1Wq5d+8eP/30E926dUOj0WBqaqruwP7ZZ5/RuXNnunXrRo0aNQDZiFYIIXRZuazxhYSE0Lp1a3U5sYIYGRmxdetWPvzwQ5YuXUqNGjVwcHBQa3QNGzbko48+YuzYseqgGKnxCSGE7iqXwbdv3758mzmflJCQoO7/98svv/DgwYNc57z//vukp6ezbNkyQIJPCCF0WbkMvoL69560aNEi0tLSAFAURQ237AwMDFi3bh0LFizg8uXLEnxCCKHDyt0E9tjYWFxdXYmJiSlUOFWtWpX4+HhSU1MxMTHBysoqx9Jm2a1cuZL169fTq1cvFEXhs88+K+niCyGEeM7KXY0vODiYdu3aFbpGdv36dc6ePYuJiQnHjx8vcAPZyZMnY2FhwcGDB6XGJ4QQOqrcjeosSjMnPN4Xz8bGhsqVK9OoUaMCz9XX12fNmjXqprhCCCF0T7mr8e3bty/P/fcKkpKSgqmpaaHOfemll+jYsSObN29W+waFEELojnIVfPfu3SM8PJymTZsW6bqUlJQiLRhdu3ZtbGxspI9PCCF0ULkKvgMHDtCxY0cMDYvWgpucnFyk4EtPT2fkyJH4+Phw7NixohZTCCFEKSpXwVfU/r0sRa3xabVabG1tWbZsGZ6eniQnJxf5mUIIIUqHBB9F6+ODx8FXqVIlhg4dSpMmTZg9e3aRnymEEKJ0lJvgi4iIIDo6ulijLYta40tLS1OnM6xYsYJNmzYRHBxc5OcKIYR48cpN8O3fvx93d/ci77UHxWvqzAo+GxsbvL29GTt2LAkJCUV+thBCiBerXAVfcZo5oeiDW55csqxfv3507tyZGTNmFOv5QgghXhwJPp6txpflP//5Dzt37mTXrl3FKoMQQogXo1wE3+3bt0lISKBhw4bFur44g1ueDD5LS0vWrFnDhAkT8tzhQQghRNlQLoIvq7b35E7qhVWcwS15bUTbrVs3BgwYwLRp04pVDiGEEM9fuQi+ouy/l5dn7ePLbvHixfz1119s37692OURQgjx/Oh88CmK8kz9e1AyfXxZzMzMWL9+PVOnTiU6OrrYZRJCCPF86Hzw3bhxg/T0dOrWrVvse5REH1927du3Z9SoUUyePJlytt2hEELoPJ0Pvmft34OSrfFl+eyzz7h8+TI///xzscslhBCi5JWL4CvqNkRPeh7BZ2Jiwvr163nvvffy3dFdCCHEi6fTwacoyjMPbIGiD27Jb1Tnk5o3b85bb73FhAkTpMlTCCHKCJ0OvsuXL1OpUiVq1KjxTPd5HjW+LLNmzSIqKoo1a9YUt3hCCCFKkE4HX0n070HJD27JzsjICF9fX2bOnMmtW7eKWUIhhBAlpVwE37N6njU+gIYNG/Lhhx8yduxYMjMzi1NEIYQQJURngy8zM5MDBw6USPCV5AT2/HzwwQekpaWxfPnyohZPCCFECdLZ4Pvnn3+wsLDgpZdeeuZ7FafGV5jBLdkZGBiwfv16Pv/8cy5fvlzUIgohhCghOht8JdXMCUXr41MUhfT0dAwNDYv8nNq1azNv3jzGjBlDenp6ka8XQgjx7HQm+LRaLZGRkdy8eZNr167h4ODAsGHD0Gq1z3zvotT4tFothoaGxR5QM2XKFMzMzPj666+Ldb0QQohno6eU8QlmSUlJREZG8vDhQ4Ac8+GywsfS0hIHBwfMzMyK9QwXFxcOHjyIi4tLocpjZ2fHo0ePivUseLyNUvPmzdm3bx+NGjUq9n2EEEIUXZmu8UVHR3PlyhXi4uJQFCXXJPCsY3FxcVy5cqXYi0IXZXBLcQa2POmll17iq6++YvTo0aSlpT3TvYQQQhRNmQm+9u3bc/r0aQAWLlzIyJEjCQ8PL/Tw/8zMTMLDw4sVfkVt6swKvtTUVOrVq8e9e/eK/MwxY8bg5OTEggULinytEEKI4isw+ObMmZPrmL+/Pw4ODsUenOHq6srevXtzHAsICMDc3JymTZsCMG3aNKZPn17kOW9Z4ZeUlFSk67IGt9y6dQs9Pb0CP1v25cqMjY0ZN24cixcvLtLz4HEz7apVq/D29ubEiRNFvl4IIUTxFBh8fn5+uZoX/fz8GDFiRLFGNebHy8uLUaNGqa8jIyOLPdE7MzOTyMjIQp+fkZFBenp6oZsvn2zqHD58OOvXryc1NbXIZa1WrRpLly7F09OT5OTkIl8vhBCi6AoMvtjYWEJCQtTXDx48YMeOHYwePZqgoCAaNGiAubk5jo6OOUYp7tixgyZNmqDRaGjXrh3nzp0DYNSoUdy+fZt+/fpRpUoVvvrqK9LS0ti3bx/u7u7A42D56quv+PTTTwGIiIigRYsW/P777/Tp04cuXbrw66+/8s8//zBs2DA6d+6co8YVEBDA4MGDeeutt7C0tKRevXr8+eef6vtP1jg//fRT9PX10dPTo1OnTgBoNBqqVKnCkSNHAFi7di3169fHysoqR0ADODk5YWVlxdGjR4vwtf/P66+/TqNGjdTPK4QQ4vkqMPiGDh2Kr6+v+nrz5s3Uq1cPNzc3xo8fj7e3NwkJCVy4cEHdGujUqVOMGzcOb29vYmJimDRpEv379yc1NRU/Pz9eeuklAgICSExM5MMPP+Tq1avo6+vj5OQEQExMTJ5luXDhAtu2bePLL7/k22+/Ze3ataxcuZLNmzezd+9e/v777xznVq1alfv37zN//nw8PDyIjY3N877p6ekYGBgAcPDgQQDi4uJITEykbdu2/PbbbyxcuJBt27YRHR1N06ZNc/Uj1q9fn7Nnzxb4RRdkxYoV/PTTTzl+yRBCCPF8FBh8np6ebNmyRW2G8/X1xdPTE3i8+PLFixeJj4/HysqKZs2aAeDj48OkSZNo3bo1BgYGeHp6YmxsnG+NKC4uDnNzc/V1cnJynlv4TJgwAWNjY9q0aYOpqSk9e/bE2tqaqlWr0qRJkxyroWTVzIyMjHj99dd5+eWXCQwMzPP52YMvL97e3sycOZP69etjaGjI2LFjSUlJITQ0VD3H3NycuLi4fO/xNLa2tnh5eTFmzBgSExOLfR8hhBBPV2DwdejQATs7O/z9/blx4wYnTpxg+PDhAGzdupWgoCBcXFxwd3dXmwVDQ0P55ptv0Gg06p+wsLB8N2O1srIiISFBfZ2RkZHnedbW1urfjY2Nc7w2MTHJMa+uatWqOfoIXVxc8n3+04IvNDSUadOmqZ8lqzn0zp076jkJCQloNJp871EY/fv3p1OnTsyYMeOZ7iOEEKJgT53OMHr0aHx9ffHz86NHjx7Y29sD0LJlS/z9/bl37x4DBw5k6NChADg7OzN79mzi4uLUP48ePeKNN94AyLXiSZ06dVAURQ2SgkKosO7du4e+/v8+2u3bt6levToAZmZmOUIyMjJSfWZeq7E4Ozvj7e2tfpZdu3bRunVr2rVrp55z6dIl3Nzcnrnc3333HYGBgezateuZ7yWEECJvhQq+vXv34uPjozZzpqWlsXHjRh4+fIiRkREWFhZqeEycOBEvLy+OHTuGoigkJSURGBio1urs7e25ceOGen8jIyO6detGcHAwAKamps+8v96DBw/YuHEjWq2WLVu2cOnSJXr37g1AkyZN2LRpE1qtlpMnT7J79241JO3s7NDX189RvsmTJ/Pll1/yzz//qPfO3qx5584dYmNjadOmzTOVGR6vQLN27VomTJjwTE2nQggh8vfU4HN1daVdu3YkJSXRv39/9bifnx+urq5YWFjg5eXFhg0bAGjRogU+Pj68/fbbWFlZUbt2bdatW6deN3PmTBYsWIBGo1FHgk6aNAk/Pz8AbGxsnvlDvfLKK9y9exdbW1tmz57Nr7/+qt73888/5/r161hZWTF37ly6deumhnblypWZPXs27du3R6PRcPToUQYNGsRHH33EsGHDsLCwYOzYseryaQA//fST2o9ZErp168aAAQOYNm1aidxPCCFETmVmrc4OHTqwbNkymjZtyvXr14td4/n9998JDAzk5MmThTp/7969LFq0KNek+vzs3LmT77//nj/++IPU1FTc3Nw4ePAgVatWLVZ585KUlESTJk1YsmQJAwcOLLH7CiGEgJKbhf6MDh06pP7dwcGB+Pj4Yk1iT09PJyoqisTERKpUqfLU859l93VjY2P++9//FrmMT2NmZsa6desYMmQI7du3x87OrsSfIYQQFVWZWaszOzMzM5ycnHIMUCkMfX19rK2tSUtLo0mTJvz1119PvaY4u68XdRPa4mjfvj2jRo1iypQpeU7vEEIIUTxlMvjg8UCTooRfamoqgYGBDB8+nKioKJYsWcLgwYOZNWtWgTsgFLXGl5aW9sy7MxTWZ599xqVLl9i0adMLeZ4QQlQEZTb44HH41a1bF41Gg56eXq7RnlnHNBoNK1as4NNPP6VGjRp4enri5ubGmTNnuHDhAq1ateL8+fN5PqMou69DyWxLVFgmJib4+vry3nvv5TsPUQghRNGU6eCDx82etWrVolGjRlSvXh1ra2sMDQ3ZvXs3lpaWNGrUiFq1atG2bVsMDQ1JTU1l48aN1KlTh5SUFPz9/Zk2bRpdu3ZlyZIluSbIP0sf34vQvHlzpkyZwsSJE6XJUwghSkCZD74sRkZGODg4UKNGDQ4fPsysWbMYM2aMOhWhZcuWVK5cWT1/5cqVuLi4oKenx9ixYzlx4gQ7duygS5cu3Lx5Uz2vrAcfwOzZs7l79y5r1659oc8VQojySGeCL7usPq+TJ0+yZMkSABo3bkxSUhK2trY4OjrmCjNXV1f279/PgAEDaNWqFatXr0ZRlGINbnnRwWdkZISvry8ff/wxt27deqHPFkKI8kbngu/Ro0ccP34ceFxb++STTzh+/DimpqasX7+eS5cuERQUxL///W91R/cs+vr6TJ8+nf3797NixQr69+/P/fv3izy45UWM6nzSK6+8wowZMxg3blyx9yoUQgihg8F36NAhtdZlYGBAvXr11K2MRowYga2tLQ0bNmT58uUMHjw4z+2IXnnlFY4dO4abmxtr1qzh6tWrhX5+adT4skyfPp2UlBRWrFhRKs8XQojyoMys3FJYDx484MiRIyQmJvKf//xH3RUiLx988AH//e9/2bFjR77TIjw8PDh06BC9evVi6dKlT91l4fPPPyc1NZUFCxY8y8cotqtXr9KuXTsOHz5M3bp1S6UMQgih1WqJiYkhOTmZjIwMDAwMMDU1xcbGptQqB4WlczU+KysrevfuTffu3fnnn38KbPZbvHgxSUlJfPbZZ/meY2lpyfz586lSpQpubm45dmvPS2nW+ODxbhZz587F09Mz3y2chBDieUlKSuL69eucP3+eiIgIYmNjefjwIbGxsURERHD+/HmuX79OUlJSaRc1XzoXfFmsrKywtLTMsSHsk4yMjPjll19YvXp1vhvRpqSkYGlpycqVK1m1ahWenp5MmzZN3Xz3SaUdfABTp06lcuXK6iLfQlREWq2WyMhIbt68ybVr17h58yaRkZFotdrSLlq5FR0dzZUrV4iLi0NRlFxTrLKOxcXFceXKFaKjo0uppAXT2eADaNSoUb4T07M4ODiwefNmxo0bl2O7oSzZJ7D37NmTc+fOce/ePZo1a8aJEydynV8Wgk9fX5+1a9fy9ddfP/XzC1HelIcahy6Kjo4mPDy80IPrMjMzCQ8PZ8aMGYwcOfI5l65odD74zp0799Tz2rVrx6effoqHh0eOTWgh9zw+a2trfv75Z+bOnUvfvn2ZN29ejt8gS2tU55NcXFxYvHgxnp6eBS7JJkR5Ul5qHLrA1dUVU1NTqlSpQpUqVXBxceHLL78s0j0yMzOJj48nPT39OZWyeHQ6+Bo3blzoGs9bb73FK6+8wuTJk3P8sOQ3gX3YsGGcPn2ao0eP0q5dO3UXhrJQ48syduxYqlevzhdffFHaRRHiuStujUPCr/gCAgJITEzk7NmzhISE8NFHHxX5HlnzpcsSnQ6+wtb44PG6nqtWreLs2bP88MMP6vGCJrBXr16dnTt3Mm7cODp06MD333//Qhepfho9PT18fHzw8vIq9P6DQpS09u3bq3NmFUVh7NixWFlZ0apVK0JCQnj55ZfVc11dXQu992V2SUlJRQq9LFnhl9Xsqaenx7Vr14r8/JKybt06OnToUKhzx4wZwyeffALAuXPnaNeu3fMsGocOHWLHjh25atFarTbH5tsBAQGMHz+e7777ji5dutC/f38OHz6svn/nzh3efPNNOnXqxNSpU4mLi0Or1ZapvledDr569epx69YtUlJSCnV+5cqV2bp1K/Pnz1enQTxtyTI9PT2mTJnCkSNH2LRpE0FBQcTHx5dI+UtCtWrV+P777xk9enShvwdRvvXs2ZM5c+bkOu7v74+Dg0Oxm53yCq2AgADMzc1p2rQp8Pgfzz179hAeHs7x48fp2LEjly9fzvN+8+bNK3TfT2RkZLEXbsjMzCQyMrJY15YVjRs3RqPREBAQ8Nye4e3tzcCBA6lZsyYbNmxQj2fNk87uwoULuLi4sHfvXkaPHs3nn3+uBuYnn3xCvXr12Lt3LxMmTFAHFuZ1n9JSZjaiLY5KlSpRu3ZtLl26pP7gPU3t2rVZs2YNQ4cO5eTJk4XenaFOnTqEhITQvHlz5s2bR9WqVRk5cmSuHSNKw+uvv862bdv49NNP1SXcRMU1ZswYZs2axfz583P8/+nn58eIESMwNCy5H3svLy9GjRqlvg4NDcXV1RUzM7MSe8aTNY4s6enphf4sDx8+LFM1juIYMWIE3t7e9OvXj8zMTNLS0tQ/qampz/z6/PnzZGRkcOvWLcaOHUt6ejp9+/alUqVKaqhNmzYNQ0NDqlWrxqBBgwDo27cvixYtIiYmhvT0dC5evMjKlSupVKkSzZo1o2PHjgBlqrlTp4MP/tfcWdjgg8f/oY4fP86wYcOKtFanoaEhdevWZcSIESxevJjffvsNLy+vUt8hXU9Pj5UrV9K4cWMGDBhQ6KYUUT4NHDiQyZMnExISQqdOnYDHCz/s2LGDY8eOqUv6hYWFYWFhwfvvv8+///1vAHbs2MEnn3zCrVu3aNCgAV5eXjRu3JhRo0Zx+/Zt+vXrh4GBAXPmzOG9995j3759eHt7A7BmzRreeusttFotVapUYfr06XTp0oWRI0cSHh6eo4x//PEHCxcuRFEUfvvtN2rVqsXZs2d5+PAhH3zwAUFBQejr6zN27FimTJkCPK5dbt++nYYNGxIYGMiQIUOYMGECK1euZM+ePWi1Wjp37swHH3yg/kz7+vqyceNG9PT0mDVrVqG+vzFjxmBsbMyNGzc4cuQI9evXZ+XKlSxfvpzt27djbW3NvHnzqFGjBqmpqVy/fp0VK1Zw8+ZNNBoNAwcOpEGDBqSlpREbG8uWLVu4efMm1tbWODs7ExYWxvjx40lNTeX+/fucOnWKuLg4jIyMcHZ2xtLSkrS0NG7evImenh6+vr6kpaWRnJxMfHw8hoaGZGRkUKlSJYyNjalUqZL651leZ68A6OnpYWRkxLJly+jSpUuupk4bGxv1ddZ3nZycTFxcHObm5jnuVa1aNaKiosrUvONyEXzFGdKfNWqzOGt11q1bl5MnT/Lpp5/i5ubGqlWr6Nu3b5HLUJJsbW3x8vLC09OTs2fPUqVKlVItjyg9pqamDB06FF9fXzX4Nm/eTL169XBzc6NXr15s3ryZjh078uDBA3W3klOnTjFu3DgCAgJo0aIFGzZsoH///ly+fBk/Pz9CQkJYvXo13bp1A+Cff/5BX18fJycnAMaPH4+BgQGrV6/m0KFDABw4cCDPMvbq1YtZs2Zx7dq1HM1qnp6e2Nvbc+3aNZKSkujbty+mpqb06tVLfWaPHj3YvXs36enpLFu2jPDwcH766ScMDQ355JNPWL16NW+//TZ//fUXGzZsYOXKlTg6OvL+++8DMGDAAIB8a0BZNUNTU1NMTEw4d+4cbdu2xdbWFmdnZ2JiYpg2bRpNmjTB0NCQo0eP4urqSu/evYmLi8PHx4chQ4Zgb2/PH3/8gb6+Ph999BGJiYmsXbsWW1tb2rVrh6IofPTRR7zxxhv07NmT8PBwZs6cydy5c6lXrx7z58+nevXqfPzxx2o4ZS2236xZsxJvbUpOTubYsWO0atWKZcuW8dprr1GjRg11B5zCsLW1JSEhgeTkZDX8IiMj0dPTK9J9njed7uODoo3szM7AwICNGzeSnJzMrl27Cn1d1qhOExMTlixZwqZNm3jnnXeYOHEiCQkJRS5HSerfvz8dO3bkww8/LNVyiNLn6enJli1b1OYlX19fPD09gccLO1y8eJH4+HisrKxo1qwZAD4+PkyaNInWrVtjYGCAp6cnxsbGHD16NM9nZP12X1KioqLYuXMn3333HWZmZlStWpX3338/R7+Wra0tw4YNw9DQEGNjY7Zv38706dOxtLTEzMyMsWPHsnv3bgD27NlDv379qF27NqampurPxcKFC/nll18IDAzk4MGDnDp1iqtXrxIZGUliYiKenp5MmDCBR48eERsby9dff02dOnWIjIzkn3/+Yc+ePejp6REcHMy8efMwNzfn/PnzbNmyhT179jB48GDq1q3L119/zbVr19i2bRufffYZ3377LVOnTsXBwYHx48djbm5OgwYNWL58Of369WPKlCm8/vrrXLlyhaZNm6LRaLC2tuall17CwcEBa2trzM3NSUpKei5dLOPHj+fPP//k6NGjtGzZUj1uampa6OdVq1aN+vXr4+3tjVar5cyZM4SEhKj3KSvKRY2vsCM7n2RtbY2BgQEzZsygVatW1K9f/6nXPDmdoVOnTpw9e5YPPvgANzc31q9fr7Zpl4bvvvuOxo0bM3DgQHr06FFq5RClq0OHDtjZ2eHv70+rVq04ceIE27ZtA2Dr1q0sWLCAjz/+mMaNG7No0SLatm1LaGgo69evZ9myZep90tLSiIiIyPMZVlZWJfrLXmhoKFqtVv25NDAwQFEUHBwc1HPs7e3Vvz948ICUlJQcA2QURVEHwdy/fz/Hz3SjRo0AaNiwIbVr1y6wLNmfY2pqmut1YmIiABERETg7O+dYC9jFxYU7d+4QHR1Neno6zs7OOd7L/nmPHTuWY33g9PT0HH2mT0pISHjqesLFVa9ePerVq5fjWFbTdtZ32rp1a9zd3Qu8z4IFC5g3bx5du3alUaNG9O7dm8TExBzNo6VN54PP2dmZ5ORk7t+/j62tbZGuzczMJCMjg8WLFzNo0CCOHz+OhYVFgdfkNY/PwsKC1atX8/vvv/P6668zcuRIPv/8c4yNjYv8eZ6VRqNh9erVTJgwgXPnzj23HxJR9o0ePRpfX18uX75Mjx491H+8W7Zsib+/P1qtluXLlzN06FDCwsJwdnZm9uzZzJ49O8/7Pflbf506dVAUhTt37uDo6Fjk8j15v6yAyPoZS0pKwsDAgC+++EI9N/s1Go0GY2NjNm/eTNWqVXPd39bWlqioKPW6vHZqeVbVq1cnLCyMzMxMNfxu375N3bp1sbOzw9DQkLCwMDVQbt++nePzuru7s2fPnkI9KyIigrS0tBzTQ56n7Ht/Xr9+nbi4OPV1v379cpybfTqVk5MTq1evzvG+RqMpM9PAoBw0derp6RW7ny81NRVjY2PGjh1L586dGTduXK45LE8qaAJ7//79OXv2LNeuXaNFixacOXOmyGUqCT169KBv37689957pfJ8UTaMHj2avXv34uPjozZzpqWlsXHjRh4+fIiRkREWFhZq38vEiRPx8vLi2LFjKIpCUlISgYGBaq3O3t4+x7J/RkZGdOvWjeDg4GKVz97enlu3bqm/gN66dQuNRkNGRgYJCQlkZmYWWEvQ19dn0KBBfPvtt2qo3bt3T52q1K1bN3bs2MGNGzdITk5m+fLlxSpnQVq3bo2ZmRlfffUVWq2WAwcOEBAQwLBhwzAwMMDDw4N58+bx6NEjLl68yPr169Vr+/bty5UrV/Dz81PnuZ04cYJLly7l+awDBw7QtWvXUvmF2sHBId8dbp5GX18/R629LND54IPiN3dmH9H5/fffExYW9tSFn7VabYFLltnZ2bF161ZmzJhB9+7d+fLLL0tlNNNXX33FoUOH8Pf3f+HPFmWDq6sr7dq1Iykpif79+6vH/fz8cHV1xcLCAi8vL3VwSYsWLfDx8eHtt9/GysqK2rVrs27dOvW6mTNnsmDBAjQajfpzMmnSJPz8/IpVvm7duhEdHY2pqSnGxsZMnjyZnj17qkGsr6+PnZ0dGRkZWFpa5nmPd955B2dnZ8aOHYu7uztTp05VF65v3749b7zxBlOmTMHDw0MdlFOSKlWqxO+//87OnTuxtbVl6tSp+Pr6qjW85cuXk5iYiIODA2PGjGHs2LHqtebm5uzevZtNmzZRvXp1HBwc+Oijj0hNTc3zWRs3bmTy5Mkl/hkKw8zMDCcnpyKHX9bgp5Kc3lISdG4/vrxkrVzyZPX6aSIiImjevDl3794FICwsjFatWrFx40a6du2a5zVNmjThxx9/LNT0idDQUMaOHUtqairr169/ar9CSTt06BBDhw7l3LlzRW4GFqKwOnTowLJly576M6EoCufPnycwMJDAwEDOnTtH586d6dOnD71798bZ2Vmt5XXs2JFff/1V/SUzKSmJK1euFGsSu76+PnXr1i1z//gWxfnz53nzzTcL3H/0RSjKsnFZoVfa073yUi6C7/Dhw3zwwQccO3asSNfduHGDbt265Wi+2bdvHyNGjOD48eM5OqWzvPLKK2zatIlXXnmlUM/IzMxk6dKlLFiwgAULFjBp0qQXOul9xowZ3Lp1i82bN5eJyfaiYklMTGTfvn0EBgYSFBREpUqV6NOnD3369MHd3T3PqUTh4eFUq1Yt1/D3oq7VCWX7H19dlZSURGRkpDq3L3uEZP0bY2lpiYODQ5n9ZaNcBN/Dhw9xdHQkPj6+SFXxixcvMmTIEC5evJjj+FdffcW2bdsIDg7G2Ng4x07D0dHR2NraUrly5SLtNHzx4kVGjx6NnZ0da9asoXr16kX6jMWVkpJCs2bNmDNnDsOGDXshzxQV27Vr1wgKCiIwMJAjR47QqlUrevfuTZ8+fahbt+4z/QJWUjWOhg0b5rmXp7e3NyNGjCh2+SoSXd6BvVwEH/xvHcGiNCeeOnWKCRMmcOrUqRzHFUVhyJAhuLu706dPnxL7zUar1bJgwQK8vLxYtmwZQ4cOLXRZn8XJkyfp06cPZ86coVq1ai/kmaLiSEtL4+DBg2rYxcfHq0HXrVu3p46ULqryUOMQpavcBF+/fv0YO3YsHh4e+Z7Tvn17li9frvZFHD58mBkzZvDXX3/lOjciIoLIyMinjvKEojenHD9+nFGjRtG8eXOWL1+OtbV1oa67desWNWrUQKvVPnWNwt9//52ffvqJTZs2AY9Xqvn7778JCAiQJk/xzCIiIggKCiIoKIh9+/ZRr149tQmzSZMmxR4BWBS6XOMQpatUR3WW5Cry2ac0FGYVeSDfBaqjo6OJiooqVOhB0ff9atWqFadPn8bW1hY3Nzd1pYmS1L9/fy5cuKCOdp09ezYRERH8+OOPJf4sUf5lZGRw5MgRPv30U5o1a8Yrr7zC3r17GTRoEFevXuXo0aPqey8i9ODxdAoHBwdq1KhB7dq1qVGjBg4ODhJ64qlKNfjGjBmDn59froApziryT1u67MlV5CHnlkRZIVtS+349TeXKlVm6dCk//vgjEyZM4K233ir0tYX1xhtvsGrVKuDxsOv169fz0Ucf5dm3IcSTYmNj+fnnnxk1ahQODg5MmjQJrVbL999/z71799i0aROjRo2SgSNC9yil6NGjR4qFhYUSHBysHouNjVWMjY2VM2fOKIGBgUr9+vWVKlWqKNWrV1eWLFminhcQEKC4ubkplpaWStu2bZWtW7cqderUUUaOHKno6ekpJiYmipmZmbJ48WIlNTVVMTExUcLCwtTr586dq7Rp00ZxdnZWzM3NFR8fHyUuLk4ZMmSIYmNjo9jZ2Snjxo1Tjh07ppw8eVLZvn270qxZM8XMzEyxtLRUunfvrpw8eVI5efKkMmzYMMXe3l4xMzNTGjZsqBw8eDDHc4YMGaKMGDFCqVKlivLKK68oly9fVhYuXKjY2dkpTk5OytatW5WRI0cqderUUZo2bap8/PHHSsuWLRULCwulf//+SkxMjKIoinLz5k0FULRaraIoihIXF6eMGzdOcXBwUKpXr67Mnj1bSU9PV5996NAhxdXVNcd3vmjRIqVr165KRkZGyf7HFDovMzNTOXv2rLJw4UKlQ4cOirm5udK3b1/lhx9+UEJDQ0u7eEKUmFINPkVRlAkTJijjx49XX3t5eSlubm6KoiiKg4ODGiKxsbHK33//rSiKovz999+KnZ2dcvToUSU9PV1Zt26d4uLiopiYmChJSUmKi4uLsmfPHvWeFy5cUCpXrpzjuXPnzlUMDAyUjh07KhkZGcqjR4+Ufv36KR4eHkpISIiye/dupUGDBsrMmTOVkydPKj169FCmTJmiHD9+XDl8+LCyevVqNfg+++wzZe/evcrRo0eV9957T7G3t1eSk5PV5xgbGyt//PGHotVqlVGjRimurq7KggULlLS0NGXVqlVqOG3ZskUxMjJSzM3NlVOnTimJiYmKh4eHMmLECEVRcgffgAEDlDfffFNJTExUoqKilJYtWypeXl7qZ4yJiVEA5eHDh+qx9PR0pU2bNsqyZctK5L+f0G2JiYmKv7+/8uabbypOTk5KjRo1lLffflvZuXOn+v+wEOVNqa/cUpKryDs6OuaamgD5ryJfs2ZN6tSpg76+PvHx8ezatYvp06djamqKtbU1w4cPV/vfDA0NiYyMJDo6GmNjY5o0aaLep3fv3mg0GgwNDRk1ahQpKSk5dp3u2LEjPXv2xNDQkNdee43o6Gg+/vhjjIyMGDZsGLdu3SIuLo4hQ4bQokUL7OzsmDBhArdu3eLzzz9n8+bNuVZ/yW8l+6zBLID6mbOvsWdgYMD69euZP38+V69eLcp/KlFOXL9+naVLl9KrVy+qVavG999/T926ddmzZw/Xr19n2bJl9OrVq0jbdQmhS0p9keqSXEW+WbNmeS5dlt8q8paWlurglqyV4Xv27Km+ryiKurDvu+++q+53Z2FhwYgRI9R9vTZs2MBvv/1GdHQ0enp6JCUlcf/+ffU+T67sbmtrq07OzXp+YmIiGo2GSpUq8f7772NsbIy7uzvTp09Hq9XmuF/28mafnpCZmZlj0n3WZ35yoeq6desyZ84cPD09CQkJKVP7ZImSl5aWRkhIiDqJ/OHDh/Tu3ZuJEyeyefPmEp9uIERZV+rBByW3ivySJUs4f/58oVeRz8jIUH+rdXZ2plKlSuzduzfPQTW2trZ88sknAJw5c4apU6fSrFkz7t+/z/r16/nhhx+oWbMm+vr6dO3atdAjQvMSHh7OokWL6Nq1K6+99hp6enokJibmCChnZ2eMjY25f/9+voOALl26pK7J+KS33nqL7du3880338j+feXQ3bt31Xl1WdMNevfuzcaNG2natOkLG3kpRFlUJv7vL6lV5GvVqsX58+cLvYp89uCrVq0aHTt25LvvviMxMVEdpfn3338DsHfvXnWLE3Nzc/T09NDX11e3TslaVd7Hx0fdq6u4NmzYwMWLF6lWrRo1a9akcePGtGnThi1btqjnVKtWjR49ejB9+nTi4+PJzMzk+vXrOT5jcHAwr776ap7P0NfXZ+3atSxZsoQLFy48U3lF6cvIyMgxpaBhw4bs2bOHgQMHcuXKFY4ePcqcOXNo3ry5hJ6o8MrET0BJrSLfsGFDzp07V+hV5LMHH8CKFSvQarUMHTqULl268OGHH6pNjP/88w9jxoyhY8eOfPDBB0yfPh1HR0fatm1Lu3btGDx4MH379sXY2PiZlyMbNWoUY8aMwcHBgdTUVPbu3cuff/7J2rVrgcdbr8Dj/tC0tDQaNGiAlZUVQ4YMURfcBvj555+ZNGlSvs9xdXVl0aJFjB49mrS0tGcqs3jxHjx4oE4pcHBwYOLEiWi1Wr777jt1usHo0aPz3KtOiIqs3KzcAo/75Gxtbbl48WKOfrUsT64iP336dKpXr8706dOBxytBnD9//pmaKbP2ByzuJNrOnTszcuRIJkyYkOu91NRU5s6dy/r16/Hy8lL7GPMSEBCAn58fmzdvLvB5iqLQt29fWrRowfz584tVZvFiKIrChQsX1N0Nzp49i7u7O71796Z37945dvcWQuSvTPTxlZSs0Dl37hzdu3fP9f6hQ4dyvM4+gR0eN4laWlrmGAVZVJaWls9t5QhjY2MWLVpE37598fT05LfffuP777/Psw+vX79+uXZJzouenh4+Pj40adKEfv360aJFi+dRdFFMSUlJOXY3MDQ0pE+fPsyaNYvOnTvnufKQEKJgZaKpsyQVZTf2J4MPdGOn4Q4dOnD27FkqVapE48aNOXDgwDPdr3r16nz//feMHj2alJSUkimkKLbsUwocHBz4z3/+Q506ddi1a5f63quvviqhJ0QxlaumTng8x++vv/4q1JqUI0aMoHfv3rm2IdGlfb+CgoKYOHEir7/+OgsXLiz23CtFURg6dCiurq4sWbKkhEspCpKWlsahQ4fUJsy4uDi1+bJ79+757j4uhCieclnjy2suX16Sk5Pz/K3Zzs4OJyenQtf8SnOzy969e3P27FnCwsJo3rx5ri2WCktPT4+VK1eyYcOGXE3CouTdvXuXtWvXMnjwYKpWrcrMmTOxsLBgw4YNREREsHbtWoYMGSKhJ8RzUK76+ODxBpOXLl1StykpSF5NnVns7OyoXLkykZGRxMXFkZmZmSMIy9K+X7a2tmzevJmffvqJXr168e677/Lxxx8XaZFvePyZf/jhB8aMGcOZM2eoUqXKcypxxZORkcGJEyfUuXU3btygR48eDBgwgB9++EFGXgrxApW7pk6AWrVqERQUxMsvv1zgeV27duWTTz6ha9eu+Z6TkJCAm5sbPXr04KOPPirz+36FhYUxbtw4EhIS8PX1pW7dukW+h6enJ1WqVGHFihXPoYQVx4MHD9i1axdBQUH88ccfVK1alT59+tC7d2/atWtX5v7fEaLCKIX1QZ+7AQMGKJs3b37qeW3btlUOHz6c7/tarVZxd3dX9PT0FAMDA51ZtDcjI0NZtmyZYmNjoyxfvlzJzMws0vUPHjxQnJ2dld27dz+nEpZPmZmZyrlz55Qvv/xS6dixo2Jubq706dNHWblypXLr1q3SLp4Q4v+Vuz4+ePrefFmSk5MLHAzy1ltvceLECRRFoXLlysXuP3vR9PX1efvttzl8+DC+vr707NmTO3fuFPp6jUbD6tWrGT9+PA8fPnyOJdV9SUlJBAQEMHnyZFxcXOjfvz/h4eHMnDmTqKgoduzYwZQpU2SOnRBlSLkMvsJOachvB3aAO3fusGbNGnUy+6NHjzh8+HCJlvN5e/nllzl8+DAdO3akadOm/Pzzz4WenN+jRw/69OnDe++993wLqYNu3LiRY7rBt99+S+3atdm1axc3btxg+fLlMt1AiDKs3A1ugcKP7CxocIujoyMxMTH8+9//5tixY2i1Wp2s/RgaGvLpp5/y6quvMnr0aH777TdWrlyJjY3NU69dsmQJbm5u/P777zmWkqtosk83CAoK4sGDB7z66qtMmDCBX375RUZeCqFjyuXglvT0dCwtLYmKiipwZGK1atU4depUjq19njRgwADeeOMNhg0b9jyK+kIlJycza9YstmzZgo+PT74LWGd38OBBhg0bxrlz57C1tX0BpSwb7t69y86dOwkMDOTPP/+kbt269OnThz59+tCsWTNZ6FkIHVYugw+gefPmrFixgjZt2uR7jpWVFTdu3MDKyirP9zMzM7G1teXChQvPvPB0WbJ//37GjBnDq6++ytdff/3UaQvTp08nPDycX3755QWV8MXLyMjg5MmT6iTyGzdu0L17d/r06UOvXr3yXPtVCKGbyu2vrYXp58tvAnuWCxcuYGNjU65CD6BLly6cO3eOlJQUmjRpwl9//VXg+QsWLODcuXPlLvgePHjAL7/8wujRo6lWrRrjx48nJSWFb7/9lnv37rF582Y8PT0l9IQoZ8pt8D1tZKeiKKSlpWFsbJzvOcHBwbi7uz+P4pU6S0tL1q1bx5IlS/Dw8GDmzJn5bk1kamqKr68v7777LhcuXMDDw4Pff//9BZf42SmKwvnz51m8eDGdOnXCxcUFPz8/2rRpw/Hjx7lw4QJfffUV7u7uMsdOiHKsXA5ugcc1voL+cU5NTaVSpUq5dmvPLjg4uMCtf8qDQYMG0a5dOyZOnEirVq3w8/OjUaNGuc5r2bIl7u7uNG3alMzMTBwdHXViwEvW7gZBQUEEBQWhr69Pnz59+Pjjj+nSpYuMvBSiAirXwZe1t15e4VbQiE54XDs4ePAg33777fMsZplgb2+Pv78/69ato2vXrnz44Yd88MEHOZZ8mzx5Mr///jvp6enA4415y6obN26oIzAPHTpEixYt6NOnDzt37qR+/foF/rIjhCj/ym3w2dvbY2BgwN27d/PsoytoDh/Af//7X8zMzHjppZeeZzHLDD09PcaOHUuXLl3w9PQkICCA9evX4+rqyjvvvIOdnZ36i0JqaipXrlwp5RL/T9Z0g6x1MGNjY+nduzfjxo1j06ZNMt1ACJFDuQ2+7JvS5hV8T1u1JTg4mE6dOj3PIpZJrq6u7N+/n//85z+0atWKAQMG4Ovri5OTE7du3eLLL7/km2++ISIiQq1Na7VaYmJiSE5OfmFrmUZGRqpBl326ga+vL82bN5fpBkKIfJXb4IP/DXDp1atXrvee1tQZHByc5y7uFYG+vj7Tp0/Hzc2Nnj17kpmZSVRUFFu3bmXx4sVMmTKF6dOnk5SURFRUlDqxP/vMGD09PSIiIkps94rMzExOnDihNmFev36d7t27079/f1auXCkjL4UQhVZu5/EBrF27lgMHDuDr65vrvdOnTzNu3DhOnz6d6z1FUXB0dCQkJIRatWq9iKKWSZ07d+bgwYNqoJmZmXHv3j0qV65cpM16i7tfYVxcHLt27SIwMJA//vgDOzs7dRK57G4ghCiuct0eVNDSZQXV+K5fv46+vj41a9Z8nsUrEe3bt1fDW1EUxo4di5WVFa1atSIkJCTH1kyurq7s3bu30Pd+/fXX8fDwoGHDhpiZmZGUlMQnn3xS5B3qMzMzCQ8PR09Pj2vXruV7nvL/u8D36NGDTp064ezsjK+vrzrd4J9//ikz0w2ioqKoX78+qamppVoOIUTRlevga9iwIVeuXEGr1eZ6r6DJ61n9e8UZ/dezZ0/mzJmT67i/vz8ODg7qqMiiyiu0AgICMDc3p2nTpgAcOnSIPXv2EB4ezvHjx+nYsSOXL1/O837z5s1j5MiRBT5zypQp/Prrr1y4cIHExEQePHjA3LlzixR6WbLOf/ToUY7jjx49UncwcHV15fjx49SpU4ePP/6YqKgoAgMDmTp1Kq6urkV6XlEdOHAAJyenQp9vb29Ply5dWLVq1XMslRDieSjXwVe5cmWcnJzyHIFYUI3vWSaujxkzBj8/v1y7IPj5+TFixIgi74peEC8vL0aNGqW+Dg0NxdXV9bntBq/RaLh//z6ZmZnFDvDo6Ghu3ryp7mBgb2/P119/Tc2aNdm5cyc3b95kxYoV9O7dm8qVK5fwJyhZI0aMwNvbu7SLIYQoqhe7/d+L5+Hhofz888+5jm/dulUZNGhQnte89NJLyqVLl4r1vEePHikWFhZKcHCweiw2NlYxNjZWzpw5owQGBir169dXqlSpolSvXl1ZsmSJel5AQIDi5uamWFpaKm3btlXOnj2rKIqijBw5UtHT01NMTEwUMzMzZfHixUpqaqpiYmKihIWFKYqiKKtXr1aMjY0VfX19xczMTJkzZ46yf/9+xdHRUb2/i4uLsmfPHmXnzp2KkZGRYmhoqJiZmSmNGzdWFEVR4uLilHHjxikODg5K9erVldmzZyvp6emKoijKjz/+qLRt21YZPny4YmFhoYwbN07566+/lJEjRyr29vaKtbW14uHhoRw6dEg5efKkcvLkSeXdd99VbGxsFFtbW+XTTz9VAGXz5s1K7dq1FU9PT2Xz5s3KgwcPcnx/np6eyuzZsxVFUdTyL168WLGzs1McHByU7du3K4GBgUqdOnUUKysr5YsvvlCvnTt3rjJ48GBl6NChSpUqVZSmTZsqZ86cUd8HlKtXr+Z6VmJiomJiYqLo6ekpZmZmipmZmXLnzh0lIyND+fLLL5WaNWsq1tbWymuvvabExMSo12u1WsXU1FQ2mRVCx5TrGh/kv3RZfjW+W7dukZqamqNvrChMTU0ZOnRojgE1mzdvpl69eri5uTF+/Hi8vb1JSEjgwoULdO3aFYBTp04xbtw4vL29iYmJYdKkSfTv35/U1FT8/Px46aWXCAgIIDExkQ8//JCrV6+qg0YAxo8fj5eXF23btiUxMZH58+fnW8ZevXoxa9YsXn/9dRITEzl79iwAnp6eGBoacu3aNU6fPs3u3btZvXq1et3x48dxdHRk9+7djBs3jmXLlhEaGspPP/3E9u3biY6OVs//66+/2LBhAytWrGD79u0cP34cACMjIw4ePMi6det47bXX0Gg0BX6fkZGRpKSkcOfOHT777DMmTpzIhg0b+PvvvwkJCeGzzz7jxo0b6vn+/v689tprxMbGMnz4cAYOHJhnU3d2ZmZm7Ny5k+rVq5OYmEhiYiLVq1dn6dKl/PbbbwQHBxMREYGVlRVvvfWWep2hoSG1a9dWvz8hhG4o98GX3wCX/CawHzx4kI4dOz7T6h6enp5s2bKF5ORkAHx9ffH09AQe/8N/8eJF4uPjsbKyolmzZgD4+PgwadIkWrdujYGBAZ6enhgbG3P06NE8nxEXF4e5uXmxy/ikqKgodu7cyXfffYeZmRlVq1bl/fffZ9OmTeo5VatW5fXXX8fQ0BBjY2O2b9/O9OnTsbS0xMzMjLFjx7J7924A9uzZQ79+/ahduzampqa8+eab6n1SUlIKXS4jIyNmz56NkZERw4YN4/79+0ybNg1zc3MaNmxIw4YNc/z3bd68OUOGDMHIyIgPPviAlJSUfL/Dp/H29uaLL77AyckJY2Nj5s2bx6+//pqjmdfc3Jy4uLhi3V8IUTrK9Tw+yH+XhvwmsJfEwtQdOnTAzs4Of39/WrVqxYkTJ9i2bRsAW7duZcGCBXz88cc0btyYRYsW0bZtW0JDQ1m/fj3Lli1T75OWlkZERESez7CysiIhIeGZypldaGgoWq02x96EmZmZODs7q6+zv/fgwQNSUlJyDJBRFEUdxHL//n3q16+f57UZGRmFLpeNjY26dFrWLyrZ5+yZmpqSmJiovs5e3qwacX7f4dOEhoYyaNCgHJPhDQwMiIqKwtHREYCEhISn1lqFEGVLuQ++mjVrcv/+fR4+fJhj6ar8mjqDg4N57733nvm5o0ePxtfXl8uXL9OjRw/1H+uWLVvi7++PVqtl+fLlDB06lLCwMJydnZk9ezazZ8/O835P1kDr1KmDoijcuXNH/Ue4KJ68n7OzM8bGxty/fx9DQ8M81zjN/lqj0WBsbMzmzZupWrVqrvvb2toSFRWlvo6MjFT/nn0N0JIWFham/j1rGkXWyj2VK1fOMao0MjJSbSrOq4bv7OzM2rVrad++fZ7PSk9P59q1a7i5uZXkRxBCPGflvqnTwMCABg0acOHChRzH8wq+O3fuEBcXR8OGDZ/5uaNHj2bv3r34+PiozZxpaWls3LiRhw8fYmRkhIWFhRoCEydOxMvLi2PHjqEoCklJSQQGBqq1Ont7+xx9WUZGRnTr1o3g4OBilc/e3p5bt26pNbRq1arRo0cPpk+fzqVLlzAxMcHe3p6mTZvy7rvvsmXLFvT09NSA0NfXZ9CgQXz77bfExsYCcO/ePY4cOQJAt27d2LFjBzdu3CAlJQUfHx/gccA8zx0R/v77b7Zt20Z6ejrfffcdxsbG6mbETZo04aeffiIjI4M//vgjx3dnb29PTEyMugoNPF6Ye/bs2YSGhgKPR6T6+/ur7x8/fhxXV1dcXFye2+cRQpS8ch98kHdzZ17Bl9W/VxLrPLq6utKuXTuSkpJybN/j5+eHq6srFhYWeHl5sWHDBgBatGiBj48Pb7/9NlZWVtSuXZt169ap182cOZMFCxag0Wj4+uuvAZg0aRJ+fn7FKt9rr70GPG5KzOpn9PX1JS0tje7du5OWlsa9e/c4c+YMy5Yt448//sg1ReOdd97B2dmZsWPH4u7uztSpU9WQaN++PW+88QZTpkxh4MCBtGjRQr3OxsamWGUujAEDBvDLL79gZWWFn58f27ZtUye7f//99wQEBKDRaNi4cSMDBw5Ur6tXrx5vvPEGNWvWRKPREBERwbRp0+jfvz89evTA3NycNm3acOzYMfWajRs3Mnny5Of2WYQQz0e5XrIsy/fff8+VK1dYsWKFemzGjBnY29vz73//Wz02efJk6tWrVyJNnS9Khw4dWLZsmTqJ/Vk8ePCAgIAAtm3bRlBQkDoaUqPR8Ndff1G/fn2uX7/+TIM5NBrNc1sGbt68eVy7dk39ZeJ5unfvHu7u7pw+fbrANV+FEGVPhanxPTmyM6/BLbq4I8OhQ4eeKfSioqJYtWoVPXv2xNXVle3btzN48GB+/fVXjIyMsLa25tixY+pAFQcHh2LXiPX19XFwcCh2WcuSqlWrqk3CQgjdUu4Ht0Dem9I+2dQZFRXF3bt3K8RAhdu3b7N9+3a2bt3KuXPnePXVV5k4cSJbt26lSpUqwOOBG4MGDWLhwoU5amhmZmY4OTkVedmyrBGWZmZmNGzYUG0Szc7b25sRI0Y8+wcUQogCVIjgs7Ozw9TUlPDwcHW4+5PBd/DgQTp06PBcRxyWpqtXr7J161a2bdvGjRs36N+/Px9++CHdunXLs9ZiaGjIL7/8kue9snZZKO7uDM9r9/Z58+Y9l/sKIcqXChF88L/mzuzBl3104cGDB595/l5ZoigK58+fZ9u2bWzdupX79+8zaNAgvvzySzp16vTMuxvY2dlRuXJlIiMj892PDyix/fiEEKKkVJjgy1q6rE+fPkDuGl9wcLA65F5XKYrCiRMn1JqdVqtl8ODB6lJmJb0ruZmZGbVq1SqVHdiFEKK4KkzwNWrUiF27dqmvsw9uiYmJ4datW+qwfl2SkZHBoUOH2Lp1K9u3b8fMzIzBgwfzyy+/0LRp02daeq2wjIyMys2gFSFE+Vehgi9r/hvkrPGFhITQtm1bnamdpKWlsW/fPrZt24a/vz/Vq1dn8ODB7Nq1iwYNGpR28YQQokyrMMHXoEEDrl27RlpaGpUqVcrRx6cL/XuPHj1i9+7dbN26lcDAQOrVq4eHhwdHjhzRiZ3ihRCirKgwwWdiYoKrqyv//e9/ady4cY4aX3BwMEuXLi3lEuYWHx9PYGAg27ZtY/fu3TRv3pzBgwezaNGiYq3PKYQQogIFH/xvPl/jxo3VPr6HDx9y+fLlHEtqlaaYmBh+//13tm7dqi6h5uHhwQ8//ICtrW1pF08IIXRehQq+7JvSZtX4Dh06RKtWrTA2Ni61ckVERPDbb7+xbds2Tpw4Qbdu3Rg+fDgbN27MsaOEEEKIZ1ehgq9Ro0Z4e3sD/wu+kth/rzhu3rzJtm3b2LZtGxcvXqRPnz5MnTqVXr16Ubly5RdeHiGEqCgqXPBlr/GZmppy8OBBFi1a9EKef+nSJXVCeXh4OAMGDOCTTz7hX//6F5UqVXohZRBCiIquQuzOkCUzMxNLS0tCQ0OxtbUlLi6O6tWrEx0d/Vz2iFMUhTNnzqgTyh8+fIiHhweDBw+mQ4cOGBpWqN87hBCiTKhQ//JmZGSwdOlSoqKiCAwM5Pbt23z55ZclGkCZmZkcPXpUbcbU09Nj8ODBrF27llatWpX46ilCCCGKpkLU+JKSkp7rmpLp6ekcPHhQXT3F2tqawYMH4+HhQePGjV/I6ilCCCEKp9wHX3R0dLF3EShIamoqe/fuZdu2bfz++++4urri4eGBh4cHL7/8ckkUXQghxHNQbtvdGjZsyG+//fbU0Bs6dCgnT54EHjdThoeHEx0dnee5SUlJbN26leHDh+Pg4MCiRYto1KgRJ0+e5MSJE8ycOVNCTwghyrhyW+NLSkriypUrRdos1dvbm/DwcL744gvq1q2LmZkZcXFx7Nixg61bt/Lnn3/Spk0bPDw8GDhwoCzMLIQQOqjcDm6JjIwsUuhll5mZyfHjx/nqq684fPgwXbp0wcPDgzVr1mBtbV3CJRVCCPEilcsan1arxcXFhU8++YQzZ85w8+ZNKlWqxIEDB3BwcGDevHnqLgb9+vXjk08+ISMjgw8++ABFUahUqRKOjo4sXLiQXr16YW5uXsqfSAghREkpl318MTExOV4fPHiQHj16sH//fjp16sRXX32V65p27doxduxYevToQUhICL/88gsdO3aU0BNCiHKmXAZfcnJyjtdNmjShQ4cOGBgY0Lt3b65evfrUeyiKkus+QgghdF+5DL6MjIwcr21sbNS/m5iYkJqaSnp6epHvI4QQQveVy+AzMDAo1nVPTjQv7n2EEEKUXeUy+Iq77qa1tTURERFkZmaip6f3XNbvFEIIUbrKZfBlb9osim7dugHwr3/9i+HDhxf7PkIIIcqucjmdAeD69evExcUV+3qNRkOtWrVKrkBCCCHKhHJZ4wNwcHAo9k4I+vr6siqLEEKUU+U2+MzMzHBycipy+GUtVF2cXRqEEEKUfeU2+ADs7OyKFH5F2Z1BCCGEbiq3fXzZPe/9+IQQQuiOChF8WbRaLTExMSQnJ5ORkYGBgQGmpqbY2NhgZGRU2sUTQgjxAlSo4BNCCCHKdR+fEEII8SQJPiGEEBWKBJ8QQogKRYJPCCFEhSLBJ4QQokKR4BNCCFGhSPAJIYSoUCT4hBBCVCgSfEIIISoUCT4hhBAVigSfEEKICkWCTwghRIUiwSeEEKJCkeATQghRoUjwCSGEqFAk+IQQQlQoEnxCCCEqFAk+IYQQFYoEnxBCiApFgk8IIUSFIsEnhBCiQvk/c8cJHJLVXXMAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "test_preds = best_model_set.predict_proba(best_impute_set.transform(X_test))\n",
+    "build_graph(test_preds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "id": "spiritual-looking",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>impute</th>\n",
+       "      <th>model</th>\n",
+       "      <th>eval</th>\n",
+       "      <th>out</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>median</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>0.925339</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>mean</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>0.923163</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>median</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>0.860000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>mean</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>0.848000</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   impute model   eval       out\n",
+       "3  median    rf  auroc  0.925339\n",
+       "2    mean    rf  auroc  0.923163\n",
+       "1  median    rf    acc  0.860000\n",
+       "0    mean    rf    acc  0.848000"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "test_metrics = eval_set.evaluate(y_test, test_preds)\n",
+    "dict_to_df(test_metrics)[['impute', 'model', 'eval', 'out']].sort_values(['eval', 'out'], ascending=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "id": "million-variety",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>init-impute</th>\n",
+       "      <th>init-impute</th>\n",
+       "      <th>init-impute</th>\n",
+       "      <th>impute</th>\n",
+       "      <th>init-model</th>\n",
+       "      <th>init-model</th>\n",
+       "      <th>init-model</th>\n",
+       "      <th>model</th>\n",
+       "      <th>eval</th>\n",
+       "      <th>out</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>y_test</td>\n",
+       "      <td>X_test</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>y_trainval</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>0.848000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>y_test</td>\n",
+       "      <td>X_test</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>median</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>y_trainval</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>acc</td>\n",
+       "      <td>0.860000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>y_test</td>\n",
+       "      <td>X_test</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>mean</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>y_trainval</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>0.923163</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>y_test</td>\n",
+       "      <td>X_test</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>median</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>X_trainval</td>\n",
+       "      <td>y_trainval</td>\n",
+       "      <td>rf</td>\n",
+       "      <td>auroc</td>\n",
+       "      <td>0.925339</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  init-impute init-impute init-impute  impute  init-model  init-model  \\\n",
+       "0      y_test      X_test  X_trainval    mean  X_trainval  X_trainval   \n",
+       "1      y_test      X_test  X_trainval  median  X_trainval  X_trainval   \n",
+       "2      y_test      X_test  X_trainval    mean  X_trainval  X_trainval   \n",
+       "3      y_test      X_test  X_trainval  median  X_trainval  X_trainval   \n",
+       "\n",
+       "   init-model model   eval       out  \n",
+       "0  y_trainval    rf    acc  0.848000  \n",
+       "1  y_trainval    rf    acc  0.860000  \n",
+       "2  y_trainval    rf  auroc  0.923163  \n",
+       "3  y_trainval    rf  auroc  0.925339  "
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dict_to_df(test_metrics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "id": "chief-celebration",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/home/james/school/yugroup/projects/pcs_inference/pcs_pipeline/veridical-flow/vflow/pipeline.py:143: UserWarning: This figure includes Axes that are not compatible with tight_layout, so results might be incorrect.\n",
+      "  plt.tight_layout()\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "<networkx.classes.digraph.DiGraph at 0x7fec3f303fa0>"
+      ]
+     },
+     "execution_count": 26,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAb4AAAEuCAYAAADx63eqAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjMuNCwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8QVMy6AAAACXBIWXMAAAsTAAALEwEAmpwYAABn2ElEQVR4nO3dZ1RU19cG8IcO0gUEKYIFFRuKWBAVC4IVO0YwYtfEqDEao2LsGkvU2GLD3hIriIoFo4gFFBQQW8SCdAvS28Ds94Mv9y8BERAYYPZvrVlLZm7ZM87MnnPuOfvIEBGBMcYYkxKykg6AMcYYq0yc+BhjjEkVTnyMMcakCic+xhhjUoUTH2OMManCiY8xxphU4cTHGGNMqnDiY4wxJlU48THGGJMqnPgYY4xJFU58jDHGpAonPsYYY1KFEx9jjDGpwomPMcaYVOHExxhjTKpw4mOMMSZVOPExxhiTKpz4GGOMSRVOfIwxxqQKJz7GGGNShRMfY4wxqcKJjzHGmFSRl3QAjLGaTSQS4f3798jMzEReXh7k5OSgoqICHR0dKCgoSDo8JoVkiIgkHQRjrOZJT09HfHw8kpOTAQCfftXIyMgAADQ1NWFgYABVVVWJxMikEyc+xli5e/v2LaKjoyEWi7+4raysLIyNjaGnp1cJkTHG1/gYq/FsbW1x//59AB9bXWPHjoW2tjbat28Pf39/NGnSRNjWzMwMvr6+X3W+0iQ9ABCLxYiOjsbbt28hIyODiIiIYrefMmUKli1b9lUxVoaEhARYWFggOztb0qGw/+DEx1glc3R0xMKFCwvd7+XlBQMDA+Tm5pbpuEUlLW9vb6irq6NNmzYAgBs3buDy5cuIjo7GnTt30KVLFzx9+rTI4y1evBijRo0qVQzp6emlSnr58pNfSWzfvh2//vprqY5fHq5duwZjY+MSb6+vr4/u3btj586dFRgVKwtOfIxVsjFjxuDgwYP471WGgwcPwtXVFfLy5TfmbPv27fj222+FvyMjI2FmZlZh19Ti4+OFpFfaBF7aZFkduLq6YseOHZIOg/0XMcYqVUZGBmloaJCfn59wX2JiIikpKVFISAidO3eOLCwsSE1NjQwNDWnt2rXCdt7e3mRpaUmamppkY2NDoaGhREQ0atQokpGRIWVlZVJVVaXVq1dTdnY2KSsrU1RUFBEReXh4kJKSEsnKypKqqiotXLiQrl69SkZGRsLxTU1N6fLly+Tj40MKCgokLy9Pqqqq1KpVKyIiSkpKonHjxpGBgQEZGhqSu7s75ebmCse3tLSkkSNHkoaGBo0bN45u3bpFo0aNIn19fapduzYNGTKEbty4QUFBQRQUFETTp08nHR0d0tXVpV9//ZUA0KNHj4p9/dzc3Mjd3Z2ISIh/9erVpKenRwYGBnT69Gk6d+4cmZubk7a2Nq1YsULYd9GiRTR06FBydnYmNTU1atOmDYWEhAiPA6Bnz54VOldaWhopKyuTjIwMqaqqkqqqKsXExFBeXh799ttv1KBBA6pduzYNHz6c3r9/L+wvEolIRUWFXr16VcJ3B6sM3OJjrJKpqKjA2dkZBw4cEO47duwYmjZtCktLS4wfPx47duxAamoqwsPD0aNHDwDAvXv3MG7cOOzYsQPv37/H5MmT4eTkhOzsbBw8eBD16tWDt7c30tLSMGfOHDx79kwYOAIA48ePx/bt22FjY4O0tDQsWbLkszH27t0b8+fPx4gRI5CWlobQ0FAAgJubG+Tl5REREYH79+/j0qVL8PDwAACkpaUhPDwcRkZGuHTpEsaNG4fNmzcjMjISR44cwenTp/H27Vth+1u3buHQoUPYunUrTp8+jTt37gAAkpKSSvV6xsfHIysrCzExMVi6dCkmTpyIQ4cOITg4GP7+/li6dClevHghbO/l5YXhw4cjMTERLi4uGDRoEEQiUbHnUFVVhY+PDwwNDZGWloa0tDQYGhpi06ZN8PT0hJ+fH2JjY6GtrY2pU6cK+8nLy6NRo0bC68eqBk58jEmAm5sbjh8/jszMTADAgQMH4ObmBgBQUFDAo0ePkJKSAm1tbVhZWQEAdu3ahcmTJ6NDhw6Qk5ODm5sblJSUEBAQUOQ5kpKSoK6uXm4xJyQkwMfHB3/88QdUVVVRp04dzJw5E3/99RcAICcnB7q6uvjmm28gLy8PJSUlnD59GrNmzYKmpiZUVVUxduxYXLp0CQBw+fJlDBgwAI0aNYKKigomTZoEAMjKyipVXAoKCnB3d4eCggK++eYbvHv3DjNmzIC6ujqaN2+O5s2bIywsTNi+bdu2GDZsGBQUFPDTTz8hKyvrs6/hl+zYsQMrVqyAsbExlJSUsHjxYpw4caJAN6+6unqpkzmrWDyBnTEJ6Ny5M/T09ODl5YX27dvj7t27OHXqFADg5MmTWL58OebOnYtWrVph1apVsLGxQWRkJPbv34/NmzcLx8nJyUFsbGyR59DW1kZqamq5xRwZGQmRSIS6desK94nFYpiYmAj/1tfXFx778OEDsrKyCgyQISLhWt67d+9gYWEhPJZ/3NJe69PR0YGcnByAj61pAAXiUFFRQVpamvB3frzA/6ZSfO41/JLIyEgMHjwYsrL/a0PIyckhISEBRkZGAIDU1FRoaWmV6fisYnDiY0xCRo8ejQMHDuDp06dwcHAQvqzbtWsHLy8viEQibNmyBc7OzoiKioKJiQnc3d3h7u5e5PHyJ4XnMzc3BxEhJiZG+BIujf8ez8TEBEpKSnj37h2srKyQnp6ODh06oHPnzrh+/TpkZGQK7KOlpQUlJSUcO3YMderUKXR8XV1dJCQkCH/Hx8cDQIEkUhGioqKEf+ePJjU0NAQA1KpVCxkZGQViyu8q/u/rAXx8Tfbs2QNbW9siz5Wbm4uIiAhYWlqW51NgX4m7OhmTkNGjR8PX1xe7du0SujlzcnJw+PBhJCcnQ0FBARoaGkJrZuLEidi+fTsCAwNBREhPT8e5c+eEVp2+vn6Ba1kKCgqwt7eHn59fmeLT19fHq1evhBZY3bp14eDggFmzZkFLSwsvXrzA0aNHMXXqVNjZ2RWafycrK4vBgwdj/fr1SExMBAC8efMGt2/fBgDY29vj7NmzePHiBbKysrBr1y4AgLKycpniLang4GCcOnUKubm5+OOPP6CkpISOHTsCAFq3bo0jR44gLy8PFy5cKPDa6evr4/3790IlGuDjnEJ3d3dERkYC+DiH0cvLS3j8zp07MDMzg6mpaYU+J1Y6nPgYkxAzMzN06tQJ6enpcHJyEu4/ePAgzMzMoKGhge3bt+PQoUMAAGtra+zatQs//PADtLW10ahRI+zbt0/Yb968eVi+fDm0tLTw+++/AwAmT56MgwcPlim+4cOHA/jYlWhlZYWEhAT069cPFy5cwI0bN4Tt5OTk8Ouvv6J9+/aFjjFt2jSYmJhg7NixsLOzw/fffy8kCVtbW4wcORLfffcdBg0aBGtrawCo8G7BgQMH4u+//4a2tjYOHjyIU6dOCTVDN27cCG9vb2hpaeHw4cMYNGiQsF/Tpk0xcuRINGjQAFpaWoiNjcWMGTPg5OQEBwcHqKuro2PHjggMDBT2OXz4MKZMmVKhz4eVHpcsY6yG69y5MzZv3ixMYi+p7Oxs3Lx5E5cuXcLFixfx6tUr9OjRAw4ODmjSpAl69+4NWVlZ/PnnnxgzZgwSEhLwzz//oFGjRmXurtTS0kLDhg3LtG9JLF68GBEREcKPiYr05s0b2NnZ4f79+xXeimWlw9f4GKvhPm2dFYeI8PTpU1y8eBGXLl2Cv78/mjdvDgcHB2zduhXt27cvMLm+e/fumD59Onr37o1Dhw5h1qxZmDlzJpo0aVJocn5JyMrKwsDAoNT7VVV16tTB48ePJR0GKwInPsakWGJiIq5cuSK06oCPJdXGjh2LgwcPonbt2p/d18fHB1FRUejfvz+ioqJw7tw5WFtbl7pWJ/C/0ZX5FWWaN28udIl+aseOHXB1dS3ls2SsIO7qZEyK5ObmIjAwUGjVPXr0CF26dIGjo6PQhVnU6MX/EovF2LVrFxYsWIBp06Zh7ty5UFRUFB4vTfLLzc0FEQkDTBiraJz4GKvhXr58KSS6q1evon79+nBwcICjoyM6deoEJSWlUh3v+fPnmDBhAtLT07Fnzx60aNGiyO2+tB5fbm4uateujfHjx+P69ev47rvvsHLlSp7zxiocJz7GapjU1FRcvXpV6L5MTU0VEp29vX2Byd2lkZeXh02bNmHFihWYO3cufvzxxxIV1C5qBfa8vDy0a9cONjY2UFVVxYkTJ6CgoAAVFRWsX78e48ePL1OMjJUEJz7GqjmxWIx79+4Jrbp79+6hY8eOcHBwgIODA1q1alWi7sviPHr0COPHj4eioiI8PDxgbm7+Vce7ffs27OzsAHycaP/o0SMAgKKiIgwNDfHs2bNyXaWCsU/xO4uxaigmJgaXLl3CpUuX4Ovrizp16sDBwQHz5s1D165dUatWrXI5j0gkwurVq/HHH39g2bJlmDx5crlUVslPbJmZmYiIiBCqvjRs2BBBQUGc9FiF4ncXY9VAZmYmrl+/LnRfxsXFwd7eHo6OjlizZk2B+pPl5f79+xg3bhwMDAxw79491KtXr9yO/fTpU6FANxFBUVERp06dwnfffYebN2+iV69e5XYuxv6LEx9jVRARITw8XOi+vH37Nlq3bg1HR0fs2bMHbdu2FUqZlbesrCwsXboUHh4eWLt2LUaPHv3VXaVFnaNhw4aoU6cO2rVrh40bNwL4OF1h0qRJePDgAdTU1Mr1nIzl42t8jFURb9++xeXLl4UuTBUVFWGaQY8ePaChoVHhMdy6dQvjx49Hs2bNsHXr1gqfUH779m1MmDABDx8+FO5zc3ODpqYmNm3aVKHnZtKr2iS+okaGqaioQEdHR6izx1h1kpOTg1u3bgmtuufPn6Nbt25CsqvI0l3/lZ6ejvnz5+P48ePYtGkThg0bVinnFYvFMDMzg4+PD5o3bw7g46T6Fi1a4Pjx459d9YCxr1HlE9+X5gIBgKamJgwMDISqD4xVRUSEZ8+eCYnu+vXraNKkiZDoOnbsKJEfcVeuXMHEiRPRuXNnbNiwATo6OpV6/lmzZkFNTa3AivAnT56Eu7s7QkJCuM4lK3dVOvGVpvpDfskjPT29SoiMsZL58OED/vnnHyHZ5ebmConO3t6+0pPMp5KSkvDzzz/j4sWL2L59O/r27SuROAICAjBu3Dg8fPiwwLXEYcOGoXHjxli5cqVE4mI1V6UuS2Rra4v79++XaNvS1vvLX1Dy7du3XxNisV69eiVUnPiSM2fO4JtvvqmwWFjVlJubi9u3b2Px4sXo1KkT6tWrBw8PD1hYWOD8+fOIiorC7t27MWLECIkmPW9vb7Ro0QLy8vIIDw+XWNIDgA4dOiA9Pb3AdT4A2LJlC3bv3o179+5JKDJWUxWb+EryBV8UMzMz+Pr6FrjP29sb6urqJVoaJT09vdRFboH/Jb/09PRS7VcRnJycEB4ejrCwMEmHwipYZGQkdu7ciWHDhqFOnTqYMmUKMjIysHTpUrx9+xY+Pj6YOXMmmjVrVu6jI0vr7du3cHFxwcyZM3Ho0CFs27atUgbNFEdGRgbDhw/HsWPHCtxvYGCAtWvXYvz48RCJRBKKjtVExSa+8pxEun37dnz77befffzTJBsfH1/qpJdPLBYjPj6+TPuWt5EjR2Lnzp2SDoOVs7S0NJw9exbTp09HkyZN0K5dO1y/fh1OTk54+PAhQkNDsWbNGtjb21eZ61NEhL/++gstW7ZE3bp1ERYWhm7dukk6LIGzszOOHTtWaDmjb7/9FgYGBlizZo2EImM1EhXj3LlzZGFhQWpqamRoaEhr164VHvP29iZLS0vS1NQkGxsbCg0NJSKiUaNGkYyMDCkrK5OqqiqtXr2asrOzSVlZmaKiooT9Fy1aREOHDiVXV1dSV1enXbt2UVJSEo0ZM4Z0dHRIT0+Pxo0bR4GBgRQUFESnT58mKysrUlVVJU1NTerVqxcFBQVRUFAQffPNN6Svr0+qqqrUtGlT8vDwoJycHOE8w4YNI1dXV1JTU6MWLVrQ06dPaeXKlaSnp0fGxsZ08eJFIS47OzuaO3cutWvXjjQ0NMjJyYnev39PREQvX74kACQSiYiIKCkpicaNG0cGBgZkaGhI7u7ulJubKxzrxo0bZGZmVtxLzKqBvLw8Cg4OppUrV1K3bt1ITU2NunfvTqtWraJ79+5RXl6epEMsVkxMDDk5OVGzZs0oICBA0uEUSSwWk6mpKYWFhRV6LDIyknR1denhw4cSiIzVRMUmPgMDA7p+/ToRESUmJlJwcDAREQUHB5Oenh4FBARQbm4u7du3j0xNTSkrK4uIiExNTeny5cvCccLDw6lWrVoFjr1o0SKSl5en06dPU15eHmVkZNDAgQNp1KhRdOPGDbp06RI1a9aM5s2bR0FBQeTg4EDfffcd3blzh27evEkeHh5C4lu6dCn5+vpSQEAA/fjjj6Sjo0MvX74UzqOkpEQbNmwgkUhE3377LZmZmdHy5cspJyeHdu7cWSA52dnZkaGhIT148IDS0tJoyJAh5OrqSkSFE9/AgQNp0qRJlJaWRgkJCdSuXTvavn27cKz3798TAEpOTi7Tfw6TnNjYWNq3bx+5uLiQnp4eNWnShKZPn05nz56l1NRUSYdXImKxmHbv3k16enq0YMEC4fNZVc2ePZsWLFhQ5GN//vkndezYscAPS8bKqtjEZ2JiQtu3by/0xT1lypRCb9DGjRvTtWvXiKhw4rtx4wbp6+sX2H7RokXUpUsX4e/4+HhSVFSkR48eCQlt+fLl1LZtWwoKCqK+ffvS4MGD6dy5c8Ljn7upq6vTuXPn6M6dO9SmTRuSk5MjAJSUlERnzpwhVVVV4QOUkpJCAOjDhw9E9DHx/fLLL0JcDx8+JAUFBcrNzS2Q+PLjzcjIELY9cuQIdevWTfg7JyeHAFBkZGRxLzOrAjIzM+nSpUs0e/ZsatmyJWlra9OwYcNo586d9OrVK0mHV2ovX76kXr16kZWVFYWEhEg6nBK5c+cONW7cmMRicaHH8vLyqGvXrrRhw4bKD4zVOMVexDt58iSWL1+OuXPnolWrVli1ahVsbGwQGRmJ/fv3Y/PmzcK2OTk5iI2NLfI42traSE1NLXT/p/UFIyMjIRKJ0KFDB6Gfn4iEJVSmT5+O7du3w83NDRoaGnB1dcXAgQMBAIcOHYKnpyfevn0LGRkZpKen4/z589i2bZtwrVBOTg6PHz9Geno6dHV1hXJPKioqAD5et8lfB+zTuExNTSESifDu3bsCsefHW7duXeE+sVhcYN/858zri1U9RIRHjx4J0wxu3ryJVq1awcHBATt27EC7du2qZaFksViMrVu3YsmSJfj5558xa9asavM8rK2tkZOTg7CwMFhaWhZ4TFZWFh4eHrCxsYGTkxMaNGggoShZTVDsJ6Jdu3bw8vKCSCTCli1b4OzsjKioKJiYmMDd3R3u7u5F7vffkWvm5uYgIsTExMDIyKjI7UxMTKCkpITg4GCkpKQUOqauri4WLFgAAAgJCcH3338PKysrvHv3Dvv378e2bdvQoEEDyMrKonv37kJFl+zs7I9PVF4e06ZNw/Pnz/HhwweYmJjA2NgYhoaGAD7WCGzRogWSk5MRHh6OnJwcKCoq4vXr11BQUICuri6ioqIKxfvu3bvPfrE8fvwYZmZmEh81xz569+4dfH19hZJg8vLycHR0xKRJk/DXX39V+x8oT58+xYQJE0BEuHnzJpo0aSLpkErl09Gd/018wMfvkblz52LixInw9fWV+AhZVn0VO6rz8OHDSE5OhoKCAjQ0NIRW0sSJE7F9+3YEBgaCiJCeno5z584JLRx9fX28ePFCOI6CggLs7e3h5+f32XPVrVsXDg4OWL16NdLT04WpCcHBwQAAX19fJCQkAADU1dUhIyMDWVlZpKenQ05ODlpaWsjLy8OuXbuQnp4OWVlZ3Lt3Dw0bNoSMjAyaNWuGu3fv4tixYzA1NcWNGzfw+++/Y+jQoQCAuLg4nDhxAs+fP8euXbugqqoKAwMD2NraQl9fHz/++CO2bdsGAPDz80NGRgbs7e0xa9YspKSkQCwW4/nz5wWeo5+fH/r06VPq/xRWPnJycnD9+nW4u7ujXbt2aNiwIY4cOQIrKytcvXoVL1++xI4dOzBkyJBqnfRyc3OxevVq2NrawtnZWagIUx05Ozvj+PHjhUZ35vvxxx+RmpoKDw+PSo6M1SjF9YM6OjqSlpYWqaurk7W1Nfn7+wuP+fj4kLW1NWlqapKBgQENGzaMUlJSiIjI09OTTExMSFNTUxgJevbsWerdu7ew/6JFi4RBI/mSkpJo0qRJVKdOHVJVVaXGjRvTihUrKCgoiL799lvS09MjFRUVMjIyovnz51NQUBAFBgaSk5MTqaqqko6ODk2bNo3q1q1L9vb2pKGhQY0bN6amTZvSrl27iIjo8uXLZGpqKpxTJBIRAGHEaf6oTmtra1JTUyNbW1vas2cP/fHHHzRx4kQCQLa2tmRmZkYKCgqkrKxMCgoKJC8vTzo6OuTs7Ex79+6ly5cvk7m5Od26dassXdCsDMRiMT179oy2bNlCTk5OpKGhQW3btqV58+bRtWvXKDs7W9IhlrvQ0FBq27Yt2dvbCwO6qjOxWEz169en+/fvf3abBw8ekK6uboFR4oyVRqWWLOvcuTM2b978xUnsz58/R1JSUpnPo6WlhYYNGyIlJQWenp44fPgw7ty5gwEDBsDFxQX29vaf7Z7s1q0bRo0ahQkTJnzxPGKxWKgwExMTg+joaOEWEhKCly9fIi8vD4qKijA2Ni72pqmpyV03ZZCcnFygJFhWVlaBkmA1tYRddnY2VqxYgW3btmHVqlUYN25cjXn/zJ07F7KyssWWKluyZAmCgoJw5syZGvO8WeWpkrU609PT8e+//5ZpErusrCwaN25cqGB1QkIC/v77bxw5cgQvXryAs7MzXF1d0bFjxwIfnNIkvpIgInz48KFAUvzvLSoqCkT0xeSoo6Mj9R/yvLw8BAUFCYkuNDQUnTp1goODAxwdHdG8efMa/xrduXMH48aNQ8OGDbFt2zbhOnVNce/ePYwYMQL//vvvZ/8vc3JyYG1tjblz58LFxaWSI2TVXZVMfEDpa3UCJS9U/fz5cxw9ehSHDx9GdnY2Ro4cCVdXVzRr1qzcE19JpaSkFJsco6OjkZmZCSMjoyKTYv79+vr6kJWt1BKsFS4qKkpIdFeuXIGhoaHQquvSpYswMremy8jIwMKFC3Ho0CH88ccfGDFiRI1M8kSERo0a4cSJE8X2Dt29excDBgxAWFgY6tSpU4kRsuquyiY+oOTJTywWIy8vDw0bNixV1xYRISQkBEeOHMHRo0ehq6sLFxcXjBw5ssC0hKoiIyOjUJfqf28fPnxA3bp1i2051q1bt0oPcU9PT4efn5+Q7N69e4devXrBwcEBDg4ONa6FUxJ+fn6YMGGCsFp5Te3CzTdv3jwAwG+//VbsdnPmzMHr16/x119/VUZYrIao0okPKNl6fLVq1cLUqVMxZ84cODo6luk8eXl58Pf3x5EjR3Dy5Em0aNECLi4uGD58OGrXrv31T6SSZGdnIzY2ttjk+PbtW+jp6RWbHA0NDaGkpFQpMYvFYoSFhQmJ7s6dO2jbtq3QfdmmTZsa14otqZSUFPzyyy/w9vbGn3/+CScnJ0mHVCnu37+PYcOGISIiothWbWZmJlq1aoXff/9dmNfL2JdU+cSX70srsF+5cgVjxozBgwcPvnpoenZ2Ni5cuIAjR47gwoULsLOzg4uLC5ycnFCrVq3yeUISJBKJEB8fX+SgnPxbXFwctLS0ik2ORkZGZX494uPjcfnyZWFOnaamptB92a1bN6irq5fzs65+fHx8MHnyZDg6OmLt2rXVespFaRERzM3N8ffff6Nt27bFbnv9+nW4uLggPDxcql4jVnbVJvGVxA8//IDU1FTs37+/3I6ZmpoqjAwNCAgoMDJUEqtlVxaxWIw3b9588bpjrVq1vjgoR0NDA1lZWbh586bQqouMjESPHj2E7sv69etL+ilXGYmJifjxxx/h7++PXbt2wd7eXtIhScT8+fMhFouxatWqL277/fffIzs7G7t3766EyFh1V6MSX3p6OiwtLbFu3boK6fZISEjA8ePHcfjwYTx//hzOzs5wcXGBjY1NjRxk8CVEhPfv3392pOqLFy8QGxuLvLw8EBHU1dVRv359tG7dGu3bt4epqamQHLW1taXyNfyvkydPYtq0aRg+fDhWrFgBNTU1SYckMSEhIRgyZAieP3/+xfdGSkoKWrZsCQ8PD/Tq1auSImTVVY1KfABw48YNODs7IywsDLq6uhV2nhcvXggjQzMzM+Hi4gIXFxc0b968ws5Z1b1//x5XrlwRWnWysrLCyMtGjRohNTX1sy3H7OzsL7YcdXV1a+y1vvj4ePzwww8IDw/H7t27YWtrK+mQJI6I0KRJExw5cgTW1tZf3P7ChQv47rvv8ODBA6n+wcC+rMYlPgCYPXs2Xr9+XWhF54pARAgNDRVGhtauXRuurq745ptvUK9evQo/vySJRCIEBgYKie7x48fo2rWrMCilcePGJW7FpaWlfXHEampqKgwNDQtM3/jvzcDAQCitVx0QEQ4ePIiff/4Z48ePx8KFC6vM4rVVgbu7O0QiUYkXonVzc4OmpiY2bdpUwZGx6qxGJr6srCxYWVlh0aJFGDFiRKWdVywWFxgZ2qxZM7i6umLYsGHQ0dEpt/N8aaBPRXr+/LkwIOXq1ato0KCBMCilU6dOFToSNCsrCzExMYiKiiqQJD/997t376Cvr//F6RyKiooVFmdJRUVFYfLkyYiNjcWePXtgZWUl6ZCqnNDQUAwaNAgvXrwo0Y+oxMREtGjRAsePH+dWM/usGpn4gI+TW/v374+QkJACSwdVlpycHGFkqI+PD7p27QpXV1cMGDCgUFWZkirJ1A5NTU0YGBiU+Rz/lZKSgqtXrwqtuvT0dGFASq9evarcxGGRSIS4uLhiW47x8fHQ0dH54ojVimp5icVi7Ny5E7/++itmzJiBX375pUYPlPoaRISmTZvi0KFDaNeuXYn2OXnyJNzd3RESEsKtZ1akGpv4AODXX39FSEiIxOv5paamwsvLC4cPH8bt27fRv39/uLi4oFevXsIXXkpKClavXo2FCxcW2WoqTSWbklawKUpeXh7u3bsnJLr79++jY8eOQquuZcuW1X4QSl5eHhISEopNjjExMdDQ0ChUGee/t9JeS4qIiMCECROQlZWFPXv2oFmzZhX0LGuOX3/9FVlZWVi7dm2J9xk2bBjMzc2/OAGeSacanfhycnLQvn17/PjjjxgzZoykwwEAvHnzRhgZGhERgeHDh8PFxQWPHz/G5MmT0aNHD6Snp2Pr1q1o06YNVq5ciUePHmHWrFkVUr4NAKKjo4XuS19fX+jr6wuJrmvXriWaq5ednQ1LS0tcv369yrUCy0IsFuPdu3dFJsRPR66WtAC5WCzGH3/8gd9++w3z58/HjBkzqtW1SEkKCwvDgAED8OrVqxL/6IqPj4elpSV8fHy4C5kVUqMTH/DxQ9OzZ0/cu3evzGXIHB0d0aFDByxdurTA/V5eXpg8eTKio6PLVALM2NgYDg4OCAwMREREBHJycqCgoAAtLS3ExsZCXl6+Qgp2Z2Rk4Pr160KrLiEhAfb29kIXprGxMV69eoX69etDJBKV+LmtWbMGCQkJWLduXaljrY6ICElJSV+c6ygSiUBEUFZWRvfu3dGsWTMuQF4KRAQLCwvs378fHTp0KPF+Bw4cwPr163H37l3uSmYF1PjEBwArV67E1atXcenSpTJ9uRw9ehTz588vdIF92LBhMDU1LfMXvZmZGTw8PGBhYYEGDRogJydHeKxt27YICgoqlyWaGjRogAcPHgiJLiAgAG3atBFadVZWVoVaH2VJfNHR0WjdujViYmIqrdxZVSYSibBq1Sps3LgRP/zwA2xsbD5bTi4jIwNGRkaf7VI1NjZGnTp1pLaV+Ntvv0FLSwuDBw8u8aAuIkLfvn1ha2uLBQsWSCBqVmWV+wp/VZBIJKL27dvTn3/+Wab9MzIySENDg/z8/IT7EhMTSUlJiUJCQujcuXNkYWFBampqZGhoKCy+S0Tk7e1NlpaWpKmpSTY2NhQaGkpERKNGjSIZGRlSVlYmJSUlAkBKSkokIyNDzZs3J0dHR8rJyaFJkyZRnz59KCgoiM6cOUMAaOHChaSvr0/q6uo0d+5c2r9/PzVq1IjU1NRo+PDhFBQUREFBQbRo0SJq2bIlaWlpkaysLGlpadGSJUsoOTmZiIhMTU3p8uXLQqyfLg5sYmJCAEhVVZVUVVWFBXV3795NTZs2JS0tLXJwcKBXr14VeK0aNWpE165dK9PrXJMEBQVRq1atqG/fvvT69esvbp+enk7//vsv/fPPP3TgwAFauXIlTZ06lQYOHEht27YlfX19UlRUpHr16lGnTp3I2dmZfvrpJ1q/fj0dO3aMbt26Ra9fvyaRSFQJz65ypaWl0bNnzyg4OJiCg4OF93dQUJBwX0REBKWlpRXaNzIyknR1denhw4cSiJxVVVW3RH85kpeXx/79+9GlSxc4ODigYcOGpdpfRUUFzs7OOHDgALp27QoAOHbsGJo2bQpLS0v07t0bx44dQ5cuXfDhwwe8fPkSwMd1xcaNGwdvb29YW1vj0KFDcHJywtOnT3Hw4EH4+/vDw8MDPXr0QEpKCmJiYtC+fXuEh4cD+Hidoijh4eE4deoU7t+/j59++gk2Njb4888/kZubC1dXV9jb2wv1DfOvDy5fvhxHjhzBlClT4O3tjYCAgGKf8/Xr11G/fn0kJSUJLT5PT0+sXLkS3t7eMDc3x6pVqzBy5EjcunVL2M/CwgKhoaGws7Mr1WtcU2RmZmLJkiXYu3cv1q1bB1dX1xL1MtSqVQvm5uYwNzf/7DbZ2dmFRqxGRkbi5s2bwt9v3rypUgXIv9aXBnXR/3dYJSUlISUlpdB17Xr16mHp0qUYN24cbt68KbUtZlaQVCQ+AGjatCnmzZuHsWPH4urVq6X+ALi5uaFfv37YvHkzVFRUcODAAbi5uQEAFBQU8OjRI1haWkJbWxva2toAgF27dmHy5MnCdQk3NzesXLkSAQEBBRKDrKwstLS08PDhwwLFmTMzMwtMWcg3YcIEKCkpoWPHjlBRUYGjo6OwgkTr1q3x9OlTIfFpa2tjzJgxWLJkCTZu3IicnBwEBQWVqct3x44dmDdvHiwsLAB8rKW4cuVKREZGwtTUFACgrq7+VV2z1dmNGzcwfvx4WFpaIiwsDPr6+uV6fCUlJZiZmcHMzOyz2+Tm5goFyD+9BQcHFypAXly3qrGxscQKsjdv3hxbt25F8+bNi016zs7OmDNnjlDVRSwWIzo6GgAKJL/Jkyfjr7/+wubNm/Hjjz9WePys6pOaxAcAM2bMgKenJzZu3IiffvqpVPt27twZenp68PLyQvv27XH37l2cOnUKwMd5Q8uXL8fcuXPRqlUrrFq1CjY2NoiMjMT+/fuxefNm4Tg5OTmIjY0t8hza2tpITU0V/s7Lyytyu0+XSVJSUirwt7KyMjIyMoS/69Spg0uXLmHFihUFjtGsWTPExsbi+++/h66uLhQVFREVFYWsrCwMGTIEIpEIADBp0iQoKSlBUVERd+7cwZUrVzB16lQhcebl5WHr1q2wsLCAoqIinj59ilq1asHHxweKioolvikoKFTbcmRpaWmYN28eTp48iS1btmDIkCESi0VeXl5IXJ9TVAHymJgYXL58ucB9KioqJSpAXt4ePnxYokFdn1Zm2rFjB6Kjo7Fs2TKheHr+oC5ZWVl4eHjAxsYGTk5OaNCgQbnHzKoXqUp8cnJy2Lt3Lzp27Ig+ffoILZeSGj16NA4cOICnT5/CwcFB+EXfrl07eHl5QSQSYcuWLXB2dkZUVBRMTEzg7u4Od3f3Io/331aXubk5iAgxMTEwMjIql26ZN2/eoGvXrujbty/++ecfZGVlQU5ODp6enujXrx8mT54MGxsb5OTkYO3atcjIyMCoUaMQExODs2fPokOHDsjLy0NOTg50dHTQo0cPWFhYICcnR7glJSXBz88POTk5ePLkiZBEP93mS7f8QTSlSZaSusnLywv/d5cvX8akSZNgZ2eH8PDwarF2o6ysLAwMDGBgYPDZGphEhMTExEItR39//wLTOfKnzRR3K0sB8vj4+DKNZAY+Jvb4+PgClzTMzc0xd+5cTJw4Eb6+vjyCVspJVeIDgIYNG2Lp0qVwc3PDrVu3SjUNYfTo0Vi+fDnCwsKwYcMGAB9bcMePH0f//v2hqakJDQ0NIWFNnDgRgwcPhr29Pdq3b4+MjAxcu3YNXbt2hbq6OvT19fHixQvh+AoKCrC3t4efnx9cXFygoqLy1R/QDx8+4OzZs/D09MQff/yBefPmQUNDA02bNkXHjh0RHByM6dOnIzQ0FIGBgejduzeGDBmCjIwM/Pjjj+jevTsaN24MADA1NcWvv/6KxYsXo3nz5khOTsalS5cwfPhwAEBMTAwuXryIq1evlvoaEhFBJBKVKlmWJJnm5OQgLS2tXI+bm5sLBQUFEBHEYjE0NTVx9epVdOjQQeJJ+b+3sv54kpGRgY6ODnR0dGBpafnZ/7OUlJRCyfHu3bs4ffp0gQLkX+pW1dPTE1r8ZmZm+OWXX3D//n28fPkSioqKuHbtGgwMDLB48WJh0v+AAQOwYMEC5OXlYe/evSAiXLt2DcbGxvjrr78gEokKjPb88ccfcezYMXh4eGDixIllel1YzSB1iQ8ApkyZgtOnT2PNmjWYP39+ifczMzNDp06dEBoaWmAl7IMHD+KHH35AXl4emjRpgkOHDgEArK2tsWvXLvzwww949uwZVFRU0LlzZ2GAzLx58zBt2jTMmTMHCxYswOzZszF58mRs2bIFLi4u5VLfs0WLFoiLi4Ouri709fVx/vx5oYbhsmXLMHLkSGhrawuL7SYmJgL4ONjC3d0dtra2EIlEuHDhAgYPHoy0tDR88803iIyMhKamJnr16iUkviNHjsDNza1MAydkZGSEL+uq7vTp05g2bRr69OkDd3d3KCkplUtCzcjIQFJSUrkl6OzsbACotCSrpKQECwsLWFpaFrg/NzcXSUlJSExMxPv37/Hu3TvcuXMHZ86cQXx8PGJjY5GcnCwkx8zMTOG1vn79OtasWYNFixZh27ZtWLNmDfbt21fg/6NTp04YO3as0NWZ7/379zAwMBD+lpeXx549e9C9e3f06dOn2O5gVrNJxTy+okRFRcHKygq+vr6f/UUrKZ07d8bmzZvRpk2br5rH5+3tjbNnzyIoKKh8AyxCTavcUpS3b99i+vTpCAoKgoeHR7UYuZrfTf2lVnFVuMnKykJeXh4aGhpYvHgxQkJCEBoaij///BPAx6XAvv32W9y8eRPA/1p8HTp0KHCNL1/t2rWLXOB4yZIlCAoKkngpQyY5UtniAwATExOsXbsWbm5uuHPnTpVqady4cUP4t4GBAVJSUsp0vSO/FVUZlJSU8OTJk0o5V2UjIvz111+YOXMmvv32W+zevVtiIx5LK3+St4qKiqRDKRYRIS8vD9nZ2ULXOoACvR7KysrIzs5Gbm5uiS5RfG5w2Lx582BtbY2jR4/CxcXl64Nn1Y7UJj7g4/SCkydPYtmyZQV+KVYlqqqqMDY2LnGB6nyysrKoXbt2tR0pWVXExMTgu+++w4sXL3DmzBm0b99e0iHVGESEFy9eIDg4GPfu3RNuZWmFFbXP565vKioqYvfu3RgwYADs7e1rbA8F+zyp/laUkZHBzp07sXPnTty9e1fS4XxW/oTkkiax/JF206ZNK9B6ZCVHRPDw8EDr1q3Rpk0bBAcHc9L7CmKxGE+fPsWRI0cwe/Zs9OjRA9ra2ujevTuOHDkCVVVVzJgxAw8ePICysnKpk1/t2rURGxsr/DiUkZEptpXbrl07jB49GtOnT/+q58WqJ6lu8QFA3bp1sWnTJri5uSE4OLjKdgnp6emhVq1alb4enzR6+fIlJk6ciKSkJFy5cgWtWrWSdEjVSm5uLp4+fYp79+4JrbmQkBDo6urCysoKbdu2xS+//AIrK6siVw8py0hUe3t7+Pj4oGfPnjA0NMSRI0e+ODhsyZIlsLS0hJeXFwYOHFjqc7LqS2oHt/yXs7Mz6tWrh99//13SoXyRSCTC69evceLECQwdOrRSV2CvyfLy8rBlyxYsW7YMc+bMwU8//VSmVTekiUgkwqNHjwokubCwMBgaGgpJzsrKCm3atCnVHMfyKM5ektKE169fh4uLC8LDw6GlpVXm87HqhRPf/3v37h1atWqFY8eOoXPnzpIO54uio6PRoUMHxMTESDqUGuHJkycYP348ZGVlsXv37gIDLNhH2dnZCA8PL3BN7uHDhzA1NS2Q5Fq3bg1NTc2vOldFLMf1OVOnTkVWVhZ2795d6nOx6okT3ye8vLwwa9YshIaGVvmuwoiICDg6OuL58+eSDqVaE4lE+P3337Fu3TosXrwY33//PQ8Iwsc6sWFhYQVack+ePEGjRo1gZWUlJDpLS8tSr0JfUl8qUF2U3NxcNGjQoEQLMOdLSUlBy5Yt4eHhgV69epUlVFbNcOL7Dzc3N6irq2PLli2SDqVY4eHhGDFiBB4+fCjpUKqtkJAQjBs3Drq6uti5c2exxZ9rsrS0NISGhhZIchEREWjatGmBJNeyZctKn8ZRmuQnIyODPXv2oGHDhpg5c2apznPhwgV89913ePDgQYUlclZ1cOL7j6SkJLRs2RJ79+6Fvb29pMP5rODgYEyaNAnBwcGSDqXayc7OxrJly7Bz506sXr0aY8aMkZqJzMnJyQgJCSmQ5F69eoXmzZsLXZVt27ZFixYtqszSRenp6SUe1PX+/Xt07twZq1evxsiRI0t1Hjc3N2hqamLTpk3lFzyrkvjK/X9oaWnBw8MD48ePR1hY2Fdfq6goWVlZUFZWlnQY1U5AQADGjx8Pc3NzhISEwNDQUNIhVZjExETcv3+/QJKLiYlBq1at0LZtW/To0QM///wzmjVrVqUHRamqqqJhw4YQiUR4//59sSuwq6qq4vz58+jZsyd0dXVL1XW5YcMGtGjRAiNGjBDK+rGaiVt8nzFlyhSIRKIqe8H7ypUrWLlyJa5cuSLpUKqFjIwMLFiwAEeOHMHGjRvh7Oxco1p5b9++FQac5Ce5t2/fonXr1gVack2aNJGKkar+/v4YOnQofHx8hLUpS+LkyZNwd3dHSEgI/7CswTjxfUZqaiosLS2xadMm9O/fX9LhFHLu3Dn8+eefOHfunKRDqfKuXr2KCRMmoGPHjti4cSN0dXUlHdJXiYuLK5TkkpOTC4ystLKygrm5uVSvOO7p6Ynvv/8e/v7+JZrakG/YsGEwNzfHb7/9VoHRMUmq+T/9ykhdXR179+6Fi4sLwsLCymWlhPLEXZ1flpKSgjlz5uDcuXPYtm1blfwBUxwiQnR0dKEkl52dLSQ3FxcX/P7772jQoAGPRv2PQYMGISEhAY6Ojrh586awfuaXbNmyBZaWlhg+fDisrKwqOEomCZz4imFnZ4fhw4dj2rRpOHLkiKTDKSArK6vKDD6ois6fP48pU6agd+/eCA8Pr7LXavMREV69elUoyQEQWnHjxo3Dli1bYGpqWqO6aSvS5MmTERcXh759++LatWtQV1f/4j4GBgZYu3Ytxo0bh7t371bp65+sbLir8wsyMjLQpk0brFixAsOGDZN0OILdu3fj5s2b2LNnj6RDqVLev3+PGTNm4NatW/Dw8ECPHj0kHVIhYrEYz58/L5TklJWVC1yPs7KygpGRESe5r0REmDJlCl68eIFz586VaMUSIkLfvn1ha2uLBQsWVEKUrDJx4iuBgIAADBo0CKGhoSXuLqloW7duxcOHD4W1yqQdEeHEiROYPn06RowYgRUrVlSJIgR5eXl49uyZkNyCg4Nx//59aGlpFZgj16ZNG9StW1fS4dZYeXl5GDZsGFRUVHDo0KESdQu/fv0abdu2hZ+fn7DqO6sZOPGV0Lx58/DkyROcOnWqSvwCX79+PaKjo7F+/XpJhyJxcXFxmDp1Kh4/fozdu3ejU6dOEokjNzcXT548KZDkQkNDUadOnUJJrjSVRVj5yMzMhIODA9q1a4d169aV6HO8bds27N+/Hzdv3pTqgUI1DV8NL6HFixcjIiIChw8flnQoAKR3cEtiYiI2btwIIgIRYd++fbC0tISFhQXu379faUkvJycHISEh2L17N6ZOnYqOHTtCU1MTQ4cOxYULF2BsbIylS5fi9evXeP78OY4fP4558+bBwcGBk56EqKio4MyZM7h06RLWrVtXon0mT54MJSUlntRew/DglhJSUlLC/v370bt3b3Tv3h1GRkYSjaemJL6STEr+1OzZs7F3717Iycnh7NmzSEhIwMWLF9GmTZsKizErK6tAcebg4GA8evQI9evXF1pyI0aMQOvWraGhoVFhcbCvp62tjQsXLsDW1hb6+vr49ttvi91eVlYWHh4esLGxgZOTU6mmRbCqi7s6S2np0qW4ffs2zp8/L9Euzzlz5kBXVxdz5syRWAxfozRlqPKv1YWGhsLGxgaZmZmQkZHB3LlzsWTJknIddZeRkYGwsLACKxA8ffoU5ubmhYozV4VriKxsHj16hO7duws/Zr/k999/x/nz53HlypUqcamDfR1OfKUkEolgY2ODyZMnY+LEiRKLY/r06WjUqFG1XEG6NIWH81eT19XVRcuWLYWi3HJycujfvz88PT3LHEdaWhpCQkIKJLnnz5/DwsKiUHHmqrpAMSu7W7duYeDAgTh//jzatWtX7La5ubno1KkTJkyYgEmTJlVShKyicFdnKSkoKGD//v3o1q0bevXqJbGK/tV1Hl9pl5oRi8WIjo7G1atX8fDhQ8jLy4OIoK2tjbS0tBKfNzk5Gffv3y+Q5F6/fo0WLVrAysoKnTt3xowZM9C8efNq+bqy0uvUqRN2794NJycn+Pn5FbsGo7y8PPbs2YPu3bujb9++MDY2rsRIWXnjwS1l0Lx5c/z8888YO3ZsmRbKLA/lfY3P1tYW9+/fB/Cx23Hs2LHQ1tZG+/bt4e/vjyZNmgjbmpmZwdfXt9TnSE9PL/X6asDH5NeoUSNcvHgRkZGRyMvLw9mzZ5GTkwN3d/dC2ycmJsLX1xdr1qzBiBEjYG5uDiMjI7i7u+PVq1ewt7fH33//jaSkJAQGBmLbtm2YOHEirKysSpT09u3bV+LFiseMGSPMAwsLC5PYiFNWNCcnJyxbtgy9e/dGfHx8sdu2aNECP/zwA6ZMmQLuKKveOPGV0axZs5CdnV1h6/Y5Ojpi4cKFhe738vKCgYEBMjIyypT4ikpa3t7eUFdXFwaI3LhxA5cvX0Z0dDTu3LmDLl264OnTp0Ueb/HixRg1alSJzh0fH1/mHwpEhIYNGwqrKfTu3Ru3bt2Ct7c3Lly4gJUrV2Lo0KGoX78+zMzMsGzZMsTFxaF///7w8vJCcnIybt68ic2bN2Ps2LFo1apVpVfkaNWqFbS0tODt7V2p52XFmzBhAsaNG4c+ffogJSWl2G3nzZuH169fV7lKTqx0OPGVkZycHPbv34+lS5fi33//LffjjxkzBgcPHiz0y/LgwYNwdXWFSCQqtxbf9u3bC4xui4yMhJmZWbkO3hCJRMJAlk/l5uaW+BjJycn45ZdfAHxcNzEvLw8PHjzAmjVr8OHDBwwbNgwXL15EUlIS/Pz8sGHDBnz77bdo1qxZlZmD5erqih07dkg6DPYf7u7u6NSpEwYPHozs7OzPbqeoqIjdu3fjp59+wps3byoxQlauiH2VTZs2kY2NDeXm5pbrcTMyMkhDQ4P8/PyE+xITE0lJSYlCQkKoTZs2VK9ePVJTUyNDQ0Nau3atsJ23tzdZWlqSpqYm2djYUGhoKBERjRo1imRkZEhZWZlUVVVp9erVlJ2dTcrKyhQVFUVERB4eHqSkpESysrKkqqpKCxcupKtXr5KRkZFwfFNTU7p8+TL5+PiQgoICycvLk6qqKrVq1YqIiJKSkmjcuHFkYGBAhoaG5O7uTtHR0RQcHEyLFi2iVq1a0ciRI0lDQ4PGjRtHt27dolGjRpG+vj7Vrl2bhgwZQjdu3KCgoCAKCgqi6dOnk46ODunq6lLPnj0JACkpKZGMjAwpKChQREREodfPzc2NvvvuO+rduzepqqpSp06dKC4ujmbMmEFaWlrUpEkTunfvnrD9o0ePyM7OjjQ1NalZs2bk5eUlPPbu3TsaMGAAqaurU7t27WjBggVka2srPP748WOyt7cnbW1taty4Mf39998F4nB3dxf+jo6OJmVlZcrKyir9m4JVqNzcXBo6dCg5OztTXl5esdv+/PPP5OzsXEmRsfLGie8r5eXlUffu3Wn16tXlfuwJEybQ+PHjhb+3b99OlpaWRESkqKhImzZtIqKPCTE4OJiIiIKDg0lPT48CAgIoNzeX9u3bR6ampsIXbX7SyhceHk61atUqcN69e/cW+GL/XOIjIlq0aBG5uroW2H/gwIE0adIkSktLo4SEBGrXrh0tX76cgoKCaNGiRSQnJ0ezZ8+mgIAAunHjBo0cOZK6dOlCV65cIT8/P+rSpQuNGTOGgoKCaNOmTVS7dm3666+/yN/fnwYMGEAAaNeuXTR58mRq1KhRgQSWz83NjXR0dCgoKIgyMzOpe/fuZGZmRvv376fc3Fxyd3enbt26ERFRTk4ONWzYkFasWEHZ2dl05coVUlNToydPnhAR0YgRI2j48OGUlpZGDx48IENDQ+H1SUtLI2NjY9qzZw+JRCIKDg4mHR0dCg8PF+L4NPEREamrqws/RljVkpmZSXZ2djRt2jQSi8Wf3S4jI4PMzc3p9OnTlRccKzfc1fmVZGVlsWfPHqxduxbh4eHlemw3NzccP34cmZmZAIADBw7Azc1NeDwmJgYpKSnQ1tYWlk/ZtWsXJk+ejA4dOkBOTg5ubm5QUlJCQEBAkedISkoqUcX6kkpISICPjw/++OMPqKqqok6dOpg5c2aB61q6urr45ptvIC8vDyUlJZw+fRqzZs2CpqYmVFVVMXbsWFy6dAkAcPnyZQwYMACNGjWCiooKpk2bBgBo1qwZOnbsiLZt20JNTa3IWAYPHoy2bdtCWVkZgwcPhrKyMkaPHg05OTmMGDFCGMwTEBCAtLQ0zJ07F4qKiujRowf69++Po0ePIi8vDydPnsTSpUuhqqqKFi1aFPg/OHv2LMzMzDB27FjIy8vDysoKQ4cOxYkTJz77GqmrqyMpKelrX2pWAZSVleHp6Ylr165h9erVn91ORUUFHh4emDp1Kj58+FCJEbLywNMZyoGZmRl+++03uLm5ISAgoNwGTXTu3Bl6enrw8vJC+/btcffuXZw6dQoAUK9ePQQGBsLU1BStWrXCqlWrYGNjg8jISOzfvx+bN28WjpOTk4PY2Ngiz6GtrY3U1NRyiRf4eH1QJBIVKLgsFothYGAg/P1poe8PHz4gKyurwAAZIhIGwbx79w4WFhbCY/nJys7ODoqKisjJycH8+fOLjOXT86ioqBT6O386RGxsLExMTAoULjY1NUVMTAzevn2L3NxcmJiYFHjs0+cbGBgILS0t4b7c3NxiK4KkpqYW2J5VLVpaWrhw4QI6deoEAwMDjBkzpsjtunbtikGDBmHWrFm8Sko1w4mvnIwfPx6nTp3CypUrsWjRonI77ujRo3HgwAE8ffoUDg4Owpe3rKwstm3bhoYNG2LLli1wdnZGVFQUTExM4O7uXuQwfwCFqk6Ym5uDiBATE1OmMmz/PZ6JiQmUlJTw7t07yMv/7+0VHx8vJN9P99HS0oKSkhKOHTuGOnXqFDq+rq4uEhISAHxMiGFhYQA+Jpf8gTFjx45Fhw4d0LdvXzg4OJRo2ZlPGRoaIioqCmKxWEh+r1+/RuPGjaGnpwd5eXlERUWhadOmwmOfPl87Oztcvny5ROeKjY1FTk5OgekhrOoxNDTEhQsX0K1bN+jp6aFfv35Fbrdq1Sq0aNECly5dgoODQyVHycqKuzrLiYyMDHbt2oWtW7cKC4iWh9GjR8PX1xe7du0SuthycnLw/v175OTkQEFBARoaGsKoxYkTJ2L79u0IDAwEESE9PR3nzp0TWnX6+vp48eKFcHwFBQXY29vDz8+vTPHp6+vj1atXQgutbt26cHBwwKxZs5CSkiKsPZdfceW/ZGVlMXjwYKxfvx6JiYkAgDdv3uD27dsAAHt7e5w9exYvXrxAdna2cJ78+Xa6urqoU6cOvL29MWTIECgpKUFDQwNeXl7w9vbGsWPHkJGRUexz6NChA1RVVbFmzRqIRCJcu3YN3t7e+OabbyAnJ4chQ4Zg8eLFyMjIwKNHj7B//35h3/79++Pff//FwYMHIRKJIBKJcPfuXTx+/LjIc127dg09evTgSfLVQNOmTeHp6YkxY8Z89lKBuro6du7ciUmTJpWqoAKTMMleYqx5Dh48SM2bNy/XUXt2dnakpaUlHDM7O5sUFRVJU1OT1NXVydramvz9/YXtfXx8yNramjQ1NcnAwICGDRtGKSkpRETk6elJJiYmpKmpKYwEPXv2LPXu3VvYvzSDW969e0e2trakpaVFbdq0IaKPozqnTJlCRkZGpKGhQa1bt6ajR49SREQELVq0iCwtLYURm0FBQXTz5k0aO3YsGRkZkaqqKpmZmdHs2bOFx3/44QfS0dGhOnXq0O7duwkAeXp6kr6+Po0dO7bAa/Xq1SvasGGD8BwVFRUJACkqKpKKigq5uLjQvn37KDg4mOTk5IT9wsPDqWvXrqShoUEWFhZ06tQp4bE3b95Qv379Pjuq88mTJ9S3b1/S1dWl2rVrU/fu3en+/ftEVHhwS9++fQuMGGVV39mzZ0lfX58eP3782W3c3Nxo2rRplRgV+xpcq7OcERGGDh2Kxo0bY9WqVRV2Hi0tLbx69arcrhV17twZmzdvLvdVDpKTkxEWFoYzZ86gTZs2sLCwKNMkdllZWTRu3LjA3ML09HSIxeIvDs558+YNPD094evri5CQEERFRQmVb4yNjWFpaYmePXti8ODBBa5FlrcHDx5g0qRJQmuWVR/79u3D4sWLcevWLaGIwqcSExPRokULHD9+HLa2thKIkJUGJ74K8ObNG7Rq1QqnT5+GjY1NhZxDWVkZSUlJVXZpovnz52PXrl1ITk6GnJwcsrKyMGfOHMyePbvUZcvyC1WX5zp2SUlJ8Pb2xsWLF4W6nenp6VBUVETdunXRsmVLdO/eHUOHDi0wmIVJr99++w1Hjx7F9evXi/zBefLkSbi7uyMkJKTKfi7ZR5z4KsiJEycwf/58hISEoFatWuV6bCKCnJwc8vLyquwSKdu2bcPMmTOFKhg6OjqIjY2FoqJimVZnKCrpNW/eHJGRkYXu37FjB1xdXUsdc0ZGBs6fP48LFy7g7t27ePnyJVJTUyEvLw99fX00b94cXbt2xZAhQwqMNGXSgYgwY8YMhIaG4uLFi0Umt2HDhsHc3By//fabBCJkJcWJrwK5urpCT08Pf/zxR7keNysrC1paWsjKyirX45an27dvo2fPnsjJyYGysjLWrVuHyZMnC4+XZT0+ScjJyYGvry/OnTuHwMBAPH/+HElJSZCTk4Oenh6aNm2Kzp07Y+DAgbCysiowJYLVPGKxGCNHjkRubi6OHTtWqBRefHw8LC0t4ePjI8ytZVUPJ74KlJiYiJYtW+LQoUPo3r17uR03KSkJpqamRda+lDQiwoYNG7Bq1Sps2rQJs2fPRk5ODqKjo4ucZlDaFdirArFYjOvXr8Pb2xu3b9/Gv//+i8TERMjIyKB27dpo3LgxOnXqBCcnJ9ja2nIyrGGys7PRp08fWFhYYMuWLYV6XQ4cOID169fj7t27VfY9LO048VWwc+fO4YcffkBYWFi5VUjJ/1WZP7+tqvjw4QPGjBmDuLg4/P3336hfvz4iIiLw/v17dOjQQdLhVSixWIzg4GB4enri5s2bePLkCd6+fQsigpaWFho1aoSOHTuiX79+6NmzZ4E5jqz6SU5Ohp2dHYYNGyYsO5WPiNC3b1/Y2toWeoxVDZz4KsH48eMhLy9fblX5X716BTs7uyKvb0lKYGAgRowYgUGDBmHNmjWlnkReU4WHh8PT0xPXr1/Ho0ePkJCQgNzcXGhoaKBBgwZo164d+vTpgz59+vCAiGomLi4Otra2mD9/PiZMmFDgsdevX6Nt27bw8/NDs2bNJBQh+6xKnTwhpZKTk8nU1JR8fHzK5XhPnjyhxo0bl8uxvpZYLKYNGzaQnp5egblv7PMiIiLo999/p379+pGpqakw11BVVZWaN29Oo0ePpkOHDlFycrKkQ2Vf8PTpUzIwMChybuaff/5JHTp0KPeVW9jX4xZfJbly5QrGjBmDsLAwaGtrf9WxQkNDMXr0aISGhpZTdGXz4cMHjBs3DtHR0fj777/RoEEDicZTncXGxgpzDcPCwhAdHY3s7GyoqKjAxMQEbdq0gb29PQYNGgRdXV1Jh8s+cffuXfTt2xeenp4F5vCJxWJ0794dgwYNwsyZMyUYIfsvTnyV6IcffkBKSgoOHDjwVccJDAzE9OnTERgYWE6Rld7du3fh7OyMAQMGYO3atVyCqwK8f/8eXl5euHz5Mu7fv4/Xr18jMzMTSkpKMDIyQqtWrdCjRw8MHjwYxsbGkg5Xql24cAFubm64evVqga7NZ8+ewcbGBoGBgWjYsKEEI2QFSLbBKV3S0tKoUaNGX72G17Vr16hr167lE1QpicVi2rhxI+np6dGJEyckEoM0S01NpSNHjpCbmxu1aNGC1NTUCAApKCiQiYkJ9enTh1avXk3//vuvpEOVOgcOHKB69eoJizrnW7t2LXXv3r3Y9f1Y5eIWXyW7efMmhg0bhrCwsDJXIrl48SLWrVsnrFlXWZKSkjB+/Hi8evUKx44d41+wVURWVhYuXrwIHx8f3LlzBy9evBAq5tSpUwfNmjVDly5dMHjwYLRq1UrS4dZoa9euxf79++Hv7y9c0sjNzUWnTp0wYcIETJo0ScIRMoC7OiXi559/FpJHWSqveHl5Yffu3Thz5kwFRFe0oKAgODs7o1+/fvj999+5a7OKy83NxdWrV3H27FkEBAQgIiICHz58gIyMDHR1ddGkSRPY2trCyckJHTp04LmG5YSIMGvWLNy9exeXLl2CiooKgI+je7t374779+9zt3QVwIlPArKysmBlZYWFCxfim2++KfX+f//9N06ePIljx45VQHQFERG2bNmCpUuX4s8//8Tw4cMr/JysYojFYty+fRtnzpzBrVu38PTpU7x//x5EBG1tbZibm8PGxgb9+/eHnZ0dzzUsI7FYjFGjRiEjIwMnTpwQXsclS5bg7t278Pb2rrKlBqUFJz4JuXv3Lvr374+QkJACq5WXxIEDB+Dr6/vVg2S+JDk5GRMmTMDz589x7NgxNGrUqELPxyQjJCQEnp6e8Pf3x+PHj/HmzRvk5eVBU1MTDRs2RPv27dG3b184Ojry/MwSysnJQb9+/dCgQQNs374dMjIyyMnJgbW1NX755Zcy1ZJl5YcTnwT9+uuvCAkJwZkzZ0r1C3Dnzp0ICgrCzp07Kyy2e/fuwdnZGQ4ODli/fj1PrpYyT58+xenTp+Hn54eHDx8iPj4eIpEI6urqMDMzg7W1NXr37o3+/fuXexH2miI1NRXdunXDgAEDsHjxYgD/+8H74MED1KlTR7IBSjFOfBKUk5OD9u3bY8aMGRg7dmyJ99u0aRMiIiKwadOmco+JiLBt2zYsWrQIW7ZswYgRI8r9HKx6ev36NU6fPo2rV68iLCwMsbGxyM7ORq1atVCvXj1YWVnBwcEBAwcOLLd1Iqu7hIQE2NraYvbs2ZgyZQoAYM6cOYiMjMTff/8t4eikFyc+CQsLC0PPnj0RHByMevXqlWifNWvW4N27d1izZk25xpKSkoKJEyfi33//xbFjx2Bubl6ux2c1T1VZ5Lcqe/78Obp06YKtW7di8ODByMzMhKWlJdasWYNBgwZJOjypxImvCli5ciWuXr2Kixcvlmh03dKlSyESibBs2bJyi+H+/ftwdnaGvb09NmzYwF2brMzyF/m9dOkS7t27h8jISKlf5Dc4OBi9e/fGqVOn0KVLF1y/fh0jR45EeHj4V1dyYqXHia8KyM3Nha2tLdzc3PD9999/cfv58+dDVVUV7u7uX31uIsKOHTvw66+/YtOmTRg5cuRXH5Ox/8rIyICPjw98fHwQFBSEFy9eFLnI7+DBg2tsUefLly9j1KhRuHLlClq0aIGpU6ciMzMTe/bskXRoUocTXxXx5MkTdO7cudjSRnl5eUhPT8evv/4KExMTzJ49+6vOmZKSgkmTJuHx48c4fvw4Gjdu/FXHY6w0pHGR36NHj2LOnDm4efMmtLW10aJFC+zatQsODg6SDk26VFqNGPZF69evp86dO3+2mvvKlStJRkaGZGRkhDJVFy5cKNO57t+/T+bm5jRp0iTKyMj4mrAZKzd5eXl09epV+umnn8jGxoZ0dHSE97yuri516tSJZs+eTX5+fpSXlyfpcMtk/fr11LRpU3r37h1duHCBjI2NKTU1VdJhSRVu8VUhYrEY3bp1w6BBg9CmTRscOnQIu3fvFh7/999/YWlpiaysLACAmpoaYmJioKGhUeJzEBF27tyJBQsW4I8//uD5RKzK+9Iivw0bNkTHjh3Rt29f9OrVq1pMvJ8zZw78/f0xffp0uLq6YsiQIThx4oSkw5IanPiqmAcPHqBdu3aQkZGBSCRCWlpagYEmvXv3xsWLF6GkpIQVK1Zg1qxZJT52amoqJk+ejAcPHuD48eNo2rRpRTwFxipFcYv81q9fX1jkt2/fvlVusJZYLEbHjh0RHBwMAFBRUcGFCxfQuXNnCUcmHTjxVSEvXrxAly5d8PbtW4hEIqipqeHu3bsFElRgYCBsbGygrq6ON2/elLhmZlhYGIYPH44uXbpg06ZNPOmY1UjPnz+Hp6cnrl69ivDwcMTFxSEnJweqqqowNTVF27Zt4ejoiAEDBpSqp6S8rVixAkuXLkVOTg4AwNDQEGpqaggJCRHqe7KKU/2vFtcg8vLy0NXVFcpCiUQivHjxosA2HTp0gJGREWbPnl2ipEdE8PDwQM+ePbFgwQJ4eHhw0mM1VsOGDTFr1iycPXsWr169QnZ2NmJiYrBmzRo0bdoUt27dwoQJE6CpqYlatWqhSZMmGDFiBHbt2oV3795VWpxGRkbQ1dWFqqoqACAuLg5NmjTBkiVLAHz87MfHx+Ply5eIiIjAy5cvheo57Otxi6+KISIcP34cU6dOxbt37zB37lz89ttvEIlEeP/+PTIzM5GXlwc5OTmoqKhAR0cHCgoKRR4rLS0N3333He7fv4/jx4/DwsKikp8NY1VTYmJioUV+MzIyoKSkBENDwwKL/JqYmFRIDEQEf39/rF27FmfPnsXy5ctx8eJF7NixA5mZmcI2+fLLGmpqasLAwEBImqz0OPFVUVlZWfj+++/RqVMndO/eHcnJyQBK/kF48OABhg8fDltbW2zevJlbeYx9QVpaGs6ePYuLFy8iKCgIr169QlpaGhQUFGBgYIAWLVrAzs4OQ4YMKfeqRklJSULrtCRfybKysjA2Ni7zmp7SjhNfFfb27VtER0dDLBZ/cdv8D4Kuri727t2LX375BevWrcPo0aMrIVLGaqYvLfJrYWEhLPJraWlZ7LGICG/evIG+vn6hx4r6rI8bNw5z5sz57CC08kh+ixcvRkREBA4dOoSEhAR069YNISEhNX69Tb7GVwXZ2trin3/+KXHSAz6OEouOjsa6deuwbt06+Pn5fTHpXbt2rcSLYi5evBijRo0C8LHwroWFBbKzs0u0L2PVlbKyMgYOHIjt27dDT08P06dPh0gkgo+PD4YPH460tDSsW7cOrVu3hqysLOrUqYMuXbpg7ty5uHXrVoHP7+XLl2FsbIxt27YVaNWZmpri5MmTBba9fv06VFVVix15nf+ZT09PL5fnqq+vj+7du1foqi9VBSe+EnB0dMTChQsL3e/l5QUDAwPk5uaW6bhmZmbw9fUtcJ+3tzdq1aoFbW3tEie9fGKxGF27doWfn1+Fln2Spg8IY/nGjBmDgwcPQk5ODr169cLGjRsRGBgIR0dHzJw5E/7+/sIqK3v27EGXLl0gLy8PHR0ddOzYEYsXL4ZYLMbs2bPxzTffICMjA8DHikz//ayfPHkSffv2/WJMYrEY8fHx5fYcXV1dsWPHjnI7XlXFia8E8t/w/+0VPnjwIFxdXct1wuz27dvRp0+fUie9fHJycsL1wIokLR8QxvINGjQIiYmJ8Pf3F+778OEDzp49Czc3NyQnJ8Pb2xshISFQUFDA6tWrce/ePUybNg2ZmZm4ffs2xGIxMjIycOzYMWhra8Pa2hqxsbH46aef0KVLF+zfvx8ikQhBQUGwsrISziMWi7Fv3z4MHDgQPXv2xNy5c4XP+bfffouNGzcWiNXS0hKnTp0CAMyYMQMmJibQ0NBA27ZtC8T/Xx06dMCLFy8QGRlZni9dlcOJrwSKe8OPHj0a58+fR7NmzaCurg4jIyP8/vvvwnZnz55F69atoaWlhU6dOiEsLAzAxzfr69evMWDAAKipqWHNmjXIycnBP//8U2D05Y4dO/DLL7/g119/RdeuXTFixAhERkZi79696NWrF/r164eAgABh+7dv32LcuHGoXbs2GjVqhF27dgmPZWZmYsyYMdDW1kazZs1w9+7dAs8zNjYWQ4cOhZ6eHurXr1/sen/S8gFhLJ+KigqcnZ1x4MAB4b5jx46hadOmsLS0xPjx47Fjxw6kpqYiPDwcPXr0QOvWreHk5IS4uDhhn/xBabVr18aQIUNgYGCA9evXw9/fH25ubnj9+jVkZGQKXAv866+/cO3aNezcuRM+Pj5QV1fH6tWrAXwsanH48GFh20ePHiEyMhL9+vUDALRr1w4hISFITEyEi4sLhg8fLlR/+i95eXk0atQIoaGh5ffCVUFVv7ZPFfDpG75r164ACr7he/fujWPHjqFLly748OEDXr58CeDjKubjxo2Dt7c3rK2tcejQITg5OeHp06c4ePAg/P394eHhAXt7ewDAw4cPhTf8p61Lf39/rFu3DosWLcLSpUsxbdo0DBw4ED4+PvD29sbKlStx5swZAIC7uzsaNGiAe/fuISkpCb169UKDBg3Qs2dPLFmyBM+fP8fz58+Rnp6OPn36COcQi8UYMGAABg4ciKNHjyI6Ohr29vZo0qQJHB0dC70mn35ApGVpmeqKiEBEEIvFxf67vO+ricdWVFTE7t27YWZmBnl5eWzbtg3NmzfHsmXLkJmZiTVr1uDcuXNQVFSEWCzGyZMn4ePjg0aNGiExMRF5eXnCZ1tWVhbDhw/Hli1bCvx/paamFpqqcOrUKcyZM0dIhpMnT0a/fv2Qm5uLbt26YdWqVYiMjISpqSkOHz6MIUOGCANU8q/NA8CsWbOwfPlyPH369LODcdTV1ZGUlFReb78qiRNfCbm5uaFfv37YvHkzVFRUcODAAbi5uQEAFBQU8OjRI1haWkJbW1tYX2vXrl2YPHkyOnToIBxj5cqVCAgIgJ2dXaFzJCUlQVVVtVCXauvWrWFjYwMAsLe3x9WrVzFmzBjIycnBwcEBK1asQGpqKtLT0xESEoINGzYgOjoaSUlJsLOzw8qVK5Gamop9+/ZhwoQJ+Oeff0BEsLGxwalTp3DkyBE8e/YMkZGRMDMzw9GjRyEWi9GmTRssXboUr1+/RnBwMN68eSNcmBeLxUhLS8Pff/+NFy9eVNqXUmV/CdaE8wEfWxn5N1lZ2UL/Lu/7auqxVVRUoKKigsDAQBgZGSE6OhqDBg1CdnY2hg4dihs3bsDX1xf6+vro1asXTE1NkZ6ejvDwcOTl5RX4XKurqxc5dUFDQ6PQgJW4uDj8/PPPQmsR+HhZIzExEXXq1EG3bt3w119/4ZdffsFff/1V4Pr7unXr4OHhgdjYWMjIyCAlJaXYyfqpqanQ0tL67OM1ASe+EurcuTP09PTg5eWF9u3b4+7du0If+smTJ7F8+XLMnTsXrVq1wqpVq2BjY4PIyEjs378fmzdvFo6Tk5OD2NjYIs+hra1d5AgtHR0d4d9KSkrQ0tKCnJyc8Dfwcb2zd+/eQUNDA6qqqnjy5AmOHDmC169fIz4+Hnv37sXbt28REBCAx48fQ1ZWFgkJCcjMzIS3tzeioqKQmJiICRMmCOciIhgYGCAwMBCxsbFISUlBaGio8CWQkpKC5ORkvHz5stRfNrKyslXqC6+qxlCS17Ekx2HlR0NDAwEBAahbty769OlT6PqaSCTCli1bsH79ekRFRSEqKgqjR4/G5s2bkZiYiFGjRmHp0qUwNjbGy5cvC/3/1KtXT5j6UKdOHQAfB5QtXLgQrVu3LjImJycnbN++HV27dkVmZia6d+8O4GNv0erVq3HlyhU0b94csrKy0NbW/uxcwdzcXERERHxxakZ1x4mvFEaPHo0DBw7g6dOncHBwELod2rVrBy8vL+EN7+zsjKioKJiYmMDd3f2zC8b+9w1vbm5e6A1fGrq6ukhJSUF6ejo6deoEV1dXzJ8/H7Gxsdi3bx/q16+P2bNno3fv3gA+tkhfvHiBo0eP4vbt2xg9ejSePXtW5LHz5/ts374dwMcPyN69e7F161bu6mRSZfTo0Vi+fDnCwsKwYcMGAB9/0B4/fhz9+/eHpqYmNDQ0hB+nEydOxODBgzFnzhwMHToUurq6uHbtGjQ1NaGiooLatWsjJiZGOL68vDzat2+Pe/fuCZ/VoUOH4s8//8SSJUtQt25dfPjwAaGhoejWrRtkZGTQp08fzJs3DwsXLsSIESOEtQvzF/vV09NDbm4uVq1ahZSUlM8+tzt37sDMzKzGf6Z5cEspjB49Gr6+vti1a5fQzZmTk4PDhw8jOTkZCgoKhd7w27dvR2BgIIgI6enpOHfuHFJTUwF8/BX3aS1OBQUFdO3aFffu3StTfAYGBmjVqhW2bt0KGRkZhIWFYffu3cLSQ87Ozvjtt9/w4cMHREdHF2iJtm/fHhoaGli9erVQFi08PLzQAJh80vIBYey/zMzM0KlTJ6Snp8PJyUm4/+DBgzAzM4OGhga2b9+OQ4cOAQCsra2xa9cuHD16FJaWlmjUqBH27dsH4GNvztixY7F7925069YNBw8eBPAx0Z0/f1449siRI9G1a1dMnToVXbt2xZgxY/Dw4UPhcUNDQwwZMgS+vr5wcXER7nd0dESfPn3QuHFjmJqaQllZudgSbIcPH8aUKVPK5XWq0oiVip2dHWlpaVFWVhYREWVnZ5OjoyNpaWmRuro6WVtbk7+/v7C9j48PWVtbk6amJhkYGNCwYcMoJSWFiIg8PT3JxMSENDU1ae3atcJ9nTp1oqCgIAoKCqKJEydSnz59hL+3bt1KdevWFf4OCAggAHTu3DkKCgqic+fOUefOnUlbW5saNGhA27ZtE2JJT0+nb7/9ljQ1NcnCwoLWrFlDRkZGwuMxMTH0zTffkL6+PmlpaVGHDh3o8uXLRES0aNEicnV1Fbb9/vvvaePGjRX3QjMmJSIiIoTP86c3S0tLOnToUJGPfXqLiIgolzgSEhKoadOmlJmZWS7Hq8q4ZFkVZG1tjZkzZ5Z5vbz8xTkryps3b2BnZ4f79+9XuXXOGKtu0tPT8e+//5Zp7q6srCwaN27MBatLiRNfFcQfBMakS2nq8ubjQtVlx9f4qiBVVVUYGxsLF6hLKv+DwEmPsepFT0+vVJ95Tnpfh1t8VVhZVmfgDwJj1Vd6ejri4+OLXIaMiCASiVCnTh1ej+8rceKr4or7IPDClIzVTEUtPK2srIyePXvixIkTFVqEXhpw4qsmyrICO2OsZpk5cya0tLSwaNEiSYdSrXHiY4yxauL27duYMGFCgTl8rPR4cAtjjFUTHTp0QGpqKie+r8SJjzHGqglZWVk4Ozvj2LFjkg6lWuPExxhj1Uh+4uOrVGXHiY8xxqqRdu3aITMzE+Hh4ZIOpdrixMcYY9WIjIwMd3d+JU58jDFWzXB359fhxMcYY9VM27ZtIRKJEBYWJulQqiVOfIwxVs1wd+fX4cTHGGPVEHd3lh0nPsYYq4batGkDIkJISIikQ6l2OPExxlg1lN/d+ffff0s6lGqHa3Uyxlg1FRISgiFDhuD58+fCai3sy7jFxxhj1ZSlpSXk5eURHBws6VCqFU58jDFWTfHozrLhrk7GGKvGwsLC4OTkhJcvX3J3Zwlxi48xxqqxli1bQllZGXfv3pV0KNUGJz7GGKvGuLuz9LirkzHGqrnw8HD07dsXkZGR3N1ZAtziY4yxaq558+ZQU1NDYGCgpEOpFjjxMcZYNcfdnaXDXZ2MMVYDPHz4EL1790ZkZCRkZblNUxx+dRhjrAZo3rw5NDU1ERAQIOlQqjxOfIwxVkNwd2fJcFcnY4zVEI8fP4a9vT2ioqK4u7MY/MowxlgNYWFhAR0dHdy6dUvSoVRpnPgYY6wG4e7OL+OuTsYYq0H+/fdf2NnZITo6GnJycpIOp0riFh9jjNUgjRs3hoGBAW7cuCHpUKosTnyMMVbDcHdn8birkzHGapiIiAh07twZMTEx3N1ZBG7xMcZYDdOoUSMYGRnh+vXrkg6lSuLExxhjNRB3d34ed3UyxlgN9OLFC3Ts2BGxsbGQl5eXdDhVCrf4GGOsBmrQoAFMTU3h5+cn6VCqHE58jDFWQ3F3Z9G4q5MxxmqoV69eoV27doiLi+Puzk9wi48xxmooMzMzNGjQAFevXpV0KFUKJz7GGKvBuLuzMO7qZIyxGiwyMhJt27ZFXFwcFBQUJB1OlcAtPsYYq8FMTU1hbm6Of/75R9KhVBmc+BhjrIbj7s6CuKuTMcZquKioKLRu3RpxcXFQVFSUdDgSxy0+xhir4UxMTNC0aVP4+vpKOpQqgRMfY4xJAe7u/B/u6mSMMSkQExODli1bIi4uDkpKSpIOR6K4xccYY1LAyMgIzZs3x+XLlyUdisRx4mOMMSnB3Z0fcVcnY4xJibi4ODRr1gxxcXFQVlaWdDgSwy0+xhiTEnXr1kWrVq1w6dIlSYciUZz4GGNMinB3J3d1MsaYVImPj0fTpk0RFxcHFRUVSYcjEdziY4wxKWJgYAArKytcvHhR0qFIDCc+xhiTMtLe3cldnYwxJmXevHmDxo0bS213J7f4GGNMytSpUwfW1tbw8fGRdCgSwYmPMcakkDR3d3JXJ2OMSaG3b9+iUaNGiIuLQ61atSQdTqXiFh9jjEkhPT09dOjQAefPn5d0KJWOEx9jjEkpae3u5K5OxhiTUu/fv0eDBg0QGxsLVVVVSYdTabjFxxhjUkpHRwc2NjY4d+6cpEOpVJz4GGNMikljdyd3dTLGmBRLTExE/fr1ERMTAzU1NUmHUym4xccYY1Ksdu3asLW1xdmzZyUdSqXhxMcYY1JO2ro7uauTMcak3IcPH2BmZoaoqChoaGhIOpwKxy0+xhiTctra2ujSpQu8vb0lHUql4MTHGGNMqro7uauTMcYYkpKSUK9ePURFRUFTU1PS4VQobvExxhiDlpYWunXrhjNnzkg6lArHiY8xxhgAYMSIEVLR3cldnYwxxgAAKSkpMDExQWRkJLS0tCQdToXhFh9jjDEAgIaGBnr06AEvLy9Jh1KhOPExxhgTSMPoTu7qZIwxJkhNTYWxsTFevXoFbW1tSYdTIbjFxxhjTKCurg57e3t4enpKOpQKw4mPMcZYATW9u5O7OhljjBWQlpYGIyMjvHjxAjo6OpIOp9xxi48xxlgBampqcHBwqLHdnZz4GGOMFVKTuzu5q5Mxxlgh6enpMDQ0xPPnz6GrqyvpcMoVt/gYY4wVoqqqit69e+P06dOSDqXcceJjjDFWpJra3cldnYwxxoqUkZEBQ0NDPHv2DHp6epIOp9xwi48xxliRatWqhT59+uDUqVOSDqVcceJjjDH2WTWxu5O7OhljjH1WZmYm6tati6dPn0JfX1/S4ZQLbvExxhj7LBUVFfTr169GdXdy4mOMMVasmtbdyV2djDHGipWVlYW6devi8ePHMDAwkHQ4X41bfIwxxoqlrKyMAQMG4OTJk5IOpVxw4mOMMfZFNam7k7s6GWOMfVF2djbq1q2L8PBwGBoaSjqcr8ItPsYYY1+kpKQEJycnnDhxAg8ePEBISIikQyozeUkHwBhjrOp78uQJsrKy8PPPPyM3Nxe9e/fGuXPnJB1WmXDiY4wxVqy8vDx07NgRaWlpyMvLAwA0a9ZMwlGVHXd1MsYYK5acnBx8fHygrKwMAFBUVETTpk0lHFXZceJjjDH2RTY2Nrh8+TKUlZUhEonQsGFDSYdUZpz4GGOMlUh+8pOVla3WiY+nMzDGGCsVsViMvLw8vH//HpmZmcjLy4OcnBxUVFSgo6MDBQUFSYdYLE58jDHGSiw9PR3x8fFITk4GAHyaQmRkZAAAmpqaMDAwgKqqqkRi/BJOfIwxxkrk7du3iI6Ohlgs/uK2srKyMDY2rpIrt3PiY4wx9kWlSXr5ZGVlceTIEcTFxeHQoUMVGF3p8OAWxhhjhZiZmUFFRQVqampQU1ODqakpfvvtt1IdQywWIyUlBbm5uRUUZdnwBHbGGGNF8vb2hr29PZ4/f46kpKQyHYOIkJmZWb6BfSVOfIwxxj5LJBIJA1mAj8nQ09MTLVu2hJeXF9TV1fHLL7/A1tYWABATE4MlS5bgyZMnaNGiBUxNTSESiSASiarMaE/u6mSMMfZZ79+/L3RfeHg4TE1N4evri9GjR2PZsmXC6M4FCxagadOm8PX1xYQJE4R6nkUdR1K4xccYY6xIgwYNgqysrJDUZsyYAXl5edStWxeDBw8GAPTv3x+rVq3C+/fvkZubi0ePHuHPP/+EoqIirKys0KVLFwCoUt2dnPgYY4wVydPTE2ZmZoW6OnV0dIS/8+t3ZmZmIikpCerq6lBRUREer1u3LhISEoTi1lUBd3Uyxhj7LDk5uRJvq6uri9TU1AKtu/j4+FIfp6Jx4mOMMfZZKioqQkWWL6lbty4sLCywY8cOiEQihISEwN/fXzhOVcFdnYwxxoo0YMAAyMnJCZPWO3ToADs7u2L3Wb58ORYvXowePXqgZcuW6Nu3L9LS0gp0j0oaV25hjDFWrK+ZxwcAWlpaVWo1B+7qZIwxViwDAwPIypYtXcjKysLAwKCcI/o6nPgYY4wVS1VVFcbGxqVOfvmFqqvaKg2c+BhjjH2Rnp5eqZIfr87AGGOsRuD1+BhjjEklkUjEK7Azxhhj1QFf42OMMSZVOPExxhiTKpz4GGOMSRVOfIwxxqQKJz7GGGNShRMfY4wxqcKJjzHGmFThxMcYY0yqcOJjjDEmVTjxMcYYkyqc+BhjjEkVTnyMMcakCic+xhhjUoUTH2OMManCiY8xxphU4cTHGGNMqnDiY4wxJlU48THGGJMqnPgYY4xJFU58jDHGpAonPsYYY1Ll/wCxxv+i+ih1IgAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "build_graph(test_metrics)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -16,13 +16,11 @@ from vflow.subkey import Subkey as sm
                 {
                     (sm('X_train', 'init'),sm('y_train', 'init'),sm('RF', 'modeling')):'RF_fitted',
                     (sm('X_train', 'init'),sm('y_train', 'init'),sm('LR', 'modeling')):'LR_fitted',
-                    PREV_KEY:('prev_0',)
                 },
-                {(sm('X_test', 'init'),):'X_test_data', PREV_KEY:('prev_1',)}
+                {(sm('X_test', 'init'),):'X_test_data'}
             ],
             # out_dict
             {
-                PREV_KEY:('prev_0','prev_1',),
                 (sm('X_train', 'init'),sm('y_train', 'init'),sm('RF', 'modeling'),sm('X_test', 'init')):('RF_fitted','X_test_data'),
                 (sm('X_train', 'init'),sm('y_train', 'init'),sm('LR', 'modeling'),sm('X_test', 'init')):('LR_fitted','X_test_data')
             }
@@ -42,7 +40,6 @@ from vflow.subkey import Subkey as sm
             ],
             # out_dict
             {
-                PREV_KEY:('prev_0','prev_1','prev_2',),
                 (sm('X_train', 'init'),sm('y_train', 'init'),sm('RF', 'modeling'),sm('X_test', 'init'),sm('y_test', 'init')):(
                     ['RF_fitted','X_test_data'],'y_test_data'
                 ),
@@ -80,7 +77,6 @@ from vflow.subkey import Subkey as sm
                     sm('LR', 'modeling'),sm('X_test', 'init'),sm('y_test', 'init')):(
                     'LR_fitted_1','X_test_data','y_test_data'
                 ),
-                PREV_KEY:()
             }
         ),
         (
@@ -119,7 +115,6 @@ from vflow.subkey import Subkey as sm
                     sm('LR', 'modeling'),sm('X_train', 'init'),sm('y_train', 'init')):(
                     'LR_fitted_1','X_train_data_1','y_train_data_1'
                 ),
-                PREV_KEY:()
             }
         ),
         (
@@ -184,7 +179,6 @@ from vflow.subkey import Subkey as sm
                     sm('voxel_extract_1', 'v_origin', True),sm('LR', 'modeling'),sm('X_test', 'init')):(
                     'LR_fitted_11','X_test_data_11'
                 ),
-                PREV_KEY:()
             }
         ),
         (
@@ -249,7 +243,6 @@ from vflow.subkey import Subkey as sm
                     sm('voxel_extract_1', 'v_origin', True),sm('LR', 'modeling'),sm('X_test', 'init')):(
                     'LR_fitted_11','X_test_data_11'
                 ),
-                PREV_KEY:()
             }
         ),
         (
@@ -288,7 +281,6 @@ from vflow.subkey import Subkey as sm
                         sm('voxel_extract_1', 'v_origin', True),sm('LR', 'modeling'),sm('X_test', 'init')):[
                         'LR_fitted_11','X_test_data_11'
                     ],
-                    PREV_KEY:()
                 },
                 {
                     (sm('y_test', 'init'),sm('subgroup_0', 's_origin', True),sm('voxel_extract_0', 'v_origin', True)):'y_test_data_00',
@@ -331,7 +323,6 @@ from vflow.subkey import Subkey as sm
                     sm('voxel_extract_1', 'v_origin', True),sm('LR', 'modeling'),sm('X_test', 'init'),sm('y_test', 'init')):(
                     ['LR_fitted_11','X_test_data_11'],'y_test_data_11'
                 ),
-                PREV_KEY:()
             }
         ),
         (
@@ -370,7 +361,6 @@ from vflow.subkey import Subkey as sm
                         sm('voxel_extract_1', 'v_origin', True),sm('LR', 'm_origin', True),sm('X_test', 'init'),sm('y_test', 'init')):[
                         ['LR_fitted_11','X_test_data_11'],'y_test_data'
                     ],
-                    PREV_KEY:()
                 },
                 {
                     (sm('LR', 'm_origin', True),sm('acc', 'metrics')):'LR_acc_func',
@@ -445,26 +435,7 @@ from vflow.subkey import Subkey as sm
                     sm('voxel_extract_1', 'v_origin', True),sm('LR', 'm_origin', True),sm('X_test', 'init'),sm('y_test', 'init'),sm('bal_acc', 'metrics')):(
                     [['LR_fitted_11','X_test_data_11'],'y_test_data'],'LR_bal_acc_func'
                 ),
-                PREV_KEY:()
             }
-        ),
-        pytest.param(
-            # in_dicts
-            [
-                {
-                    PREV_KEY: 'prev_0'  # not wrapped in tuple
-                },
-                {
-                    PREV_KEY: ('prev_1',)
-                }
-            ],
-            # out_dict
-            {
-                PREV_KEY: ('prev_0', 'prev_1')
-            },
-            # this test is expected to fail because combine_dicts() makes the
-            # assumption that PREV_KEY entries are wrapped in tuples
-            marks=pytest.mark.xfail(strict=True)
         ),
         (
             # in_dicts
@@ -492,7 +463,6 @@ from vflow.subkey import Subkey as sm
             ],
             # out_dict
             {
-                PREV_KEY:(),
                 (sm('X_train', 'init'),sm('y_train', 'init'),sm('voxel_extract_0', 'v_origin', True),sm('subgroup_0', 's_origin', True),
                     sm('RF', 'modeling'),sm('X_test', 'init'),sm('y_test', 'init')):(
                     'RF_00', 'X_test_data_0', 'y_test_data_00'
@@ -537,7 +507,6 @@ from vflow.subkey import Subkey as sm
             ],
             # out_dict
             {
-                PREV_KEY:(),
                 (sm('X_train', 'init'),sm('y_train', 'init'),sm('voxel_extract_0', 'v_origin', True),
                     sm('subgroup_0', 's_origin', True),sm('RF', 'modeling'),sm('y_test', 'init'),sm('X_test', 'init')):(
                     'RF_00', 'y_test_data_00', 'X_test_data_0'
@@ -582,7 +551,6 @@ from vflow.subkey import Subkey as sm
             ],
             # out_dict
             {
-                PREV_KEY:(),
                 (sm('X_test', 'init'),sm('subgroup_0', 's_origin', True),sm('X_train', 'init'),sm('y_train', 'init'),
                     sm('voxel_extract_0', 'v_origin', True),sm('RF', 'modeling'),sm('y_test', 'init')):(
                     'X_test_data_0', 'RF_00', 'y_test_data_00'
@@ -627,7 +595,6 @@ from vflow.subkey import Subkey as sm
             ],
             # out_dict
             {
-                PREV_KEY:(),
                 (sm('X_test', 'init'),sm('subgroup_0', 's_origin', True),sm('y_test', 'init'),
                     sm('voxel_extract_0', 'v_origin', True),sm('X_train', 'init'),sm('y_train', 'init'),sm('RF', 'modeling')):(
                     'X_test_data_0', 'y_test_data_00', 'RF_00'
@@ -672,7 +639,6 @@ from vflow.subkey import Subkey as sm
             ],
             # out_dict
             {
-                PREV_KEY:(),
                 (sm('y_test', 'init'),sm('voxel_extract_0', 'v_origin', True),sm('subgroup_0', 's_origin', True),
                     sm('X_train', 'init'),sm('y_train', 'init'),sm('RF', 'modeling'),sm('X_test', 'init')):(
                     'y_test_data_00', 'RF_00', 'X_test_data_0'
@@ -717,7 +683,6 @@ from vflow.subkey import Subkey as sm
             ],
             # out_dict
             {
-                PREV_KEY:(),
                 (sm('y_test', 'init'),sm('voxel_extract_0', 'v_origin', True),sm('subgroup_0', 's_origin', True),
                     sm('X_test', 'init'),sm('X_train', 'init'),sm('y_train', 'init'),sm('RF', 'modeling')):(
                     'y_test_data_00', 'X_test_data_0', 'RF_00'
@@ -776,7 +741,6 @@ from vflow.subkey import Subkey as sm
             ],
             # out_dict
             {
-                PREV_KEY:(),
                 (sm('X_test', 'init'),sm('feature_extraction_0', 'f_origin', True),sm('subgroup_0', 's_origin', True),
                  sm('y_test', 'init'),sm('voxel_extract_0', 'v_origin', True),
                  sm('X_train', 'init'),sm('y_train', 'init'),sm('RF', 'modeling')): ('X_test_data_00','y_test_data_00','RF_000'),
@@ -815,7 +779,6 @@ from vflow.subkey import Subkey as sm
             ],
             # out_dict
             {
-                PREV_KEY:(),
                 (sm('X_train', 'init'),sm('standardize_0', 's_origin', True),sm('y_train', 'init')):('X_train_0','y_train_data'),
                 (sm('X_train', 'init'),sm('standardize_1', 's_origin', True),sm('y_train', 'init')):('X_train_1','y_train_data')
             }

--- a/tests/test_pipelines.py
+++ b/tests/test_pipelines.py
@@ -231,6 +231,16 @@ class TestPipelines:
         h_res = h_set(g_res, h_arg, n_out=1)
         h_lazy_res = h_set(g_lazy_res, h_arg, n_out=1)
 
+        # check PREV_KEYs
+        assert_equal(h_res[PREV_KEY][0], h_lazy_res[PREV_KEY][0])
+        assert_equal(h_res[PREV_KEY][1][0], g_set)
+        assert_equal(h_lazy_res[PREV_KEY][1][0], g_lazy_set)
+        assert_equal(h_res[PREV_KEY][1][1][0], f_set)
+        assert_equal(h_lazy_res[PREV_KEY][1][1][0], f_lazy_set)
+
+        del h_res[PREV_KEY]
+        del h_lazy_res[PREV_KEY]
+
         assert_equal(h_res, h_lazy_res)
 
 

--- a/vflow/convert.py
+++ b/vflow/convert.py
@@ -171,10 +171,6 @@ def sep_dicts(d: dict, n_out: int = 1, keys: list = []):
                         value_i = value[i]
                     sep_dicts[i][new_key] = value_i
 
-        # add back prev
-        prev = d[PREV_KEY]
-        for i in range(n_out):
-            sep_dicts[i][PREV_KEY] = prev
         return sep_dicts
 
 
@@ -240,14 +236,6 @@ def combine_dicts(*args: dict, base_case=True):
                     else:
                         combined_dict[combined_key] = args[0][k0] + (args[1][k1],)
 
-        prev_tup = ()
-        for i in range(2):
-            if PREV_KEY in args[i]:
-                prev = args[i][PREV_KEY]
-                for p in prev:
-                    if p not in prev_tup:
-                        prev_tup += (p,)
-        combined_dict[PREV_KEY] = prev_tup
         return combined_dict
     else:
         # combine the first two dicts and call recursively with remaining args

--- a/vflow/helpers.py
+++ b/vflow/helpers.py
@@ -135,7 +135,7 @@ def filter_vset_by_metric(metric_dict: dict, vset: Vset, *vsets: Vset, n_keep: i
         new_vset = Vset('filtered_'+vset.name, new_vfuncs, is_async=vset._async,
                         output_matching=vset._output_matching, lazy=vset._lazy,
                         cache_dir=vset._cache_dir, tracking_dir=vset._tracking_dir)
-        setattr(new_vset, PREV_KEY, metric_dict[PREV_KEY])
+        setattr(new_vset, PREV_KEY, (metric_dict[PREV_KEY], vset,))
         vsets[i] = new_vset
     if len(vsets) == 1:
         return vsets[0]


### PR DESCRIPTION
This fixes an issue where re-using a Vset (e.g., an evaluation Vset) would cause
build_graph to fail due to a self reference in the Vset's PREV_KEY attr. Now,
only Vset.fit modifies the Vset's PREV_KEY, but output dictionaries from other
methods (predict, transform, __call__, etc.) do contain the full PREV_KEY
history.

For dictionaries, PREV_KEY is now a nested tuple like (vset1, arg1_1, arg1_2,
...), where the first entry is a reference to the vset that created the
dictionary and the following entries are similar tuples like (vset2, arg2_1,
...) representing the history of the arguments passed to vset1, or
simply ('init',) if the argument passed to vset1 was created via init_args.

A Vset's PREV_KEY is either unset or, after calling .fit, a tuple like (arg1,
arg2, ...), where the entries are tuples with 'init' or Vset refs + arg entries
as in the dict case.